### PR TITLE
feat: add golangci-lint plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ Build web interfaces that stand out. While everyone else uses the same boring ro
 /plugin install neobrutalism@aiocean-plugins
 ```
 
+## golangci-lint
+
+Stop linting your entire codebase when you only changed 10 lines. This skill teaches golangci-lint to focus on what matters - your changes. Use `--new` for unstaged changes, `--new-from-merge-base=main` for PR reviews. Handles the annoying v2 config migration (yes, `typecheck` and `gosimple` are gone). Includes common `//nolint` patterns for when you know better than the linter. Faster feedback, cleaner PRs.
+
+```bash
+/plugin install golangci-lint@aiocean-plugins
+```
+
 ## bun-fullstack-setup
 
 Ship fullstack applications with Bun the right way. Single port serves both your API and static frontend in production - no nginx configuration needed. Vite proxy handles development with hot reload. Environment validation catches missing config at startup, not runtime. PM2 config for local development. Multi-stage Docker build for lean production images. Stop copy-pasting boilerplate from Stack Overflow - get a proven setup that just works.

--- a/plugins/golangci-lint/plugin.json
+++ b/plugins/golangci-lint/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "golangci-lint",
+  "version": "1.0.0",
+  "description": "Efficient Go linting with golangci-lint. Lint only changed code, fix v2 config issues, handle common warnings.",
+  "skills": ["skills/golangci-lint"]
+}

--- a/plugins/golangci-lint/skills/golangci-lint/SKILL.md
+++ b/plugins/golangci-lint/skills/golangci-lint/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: golangci-lint
+description: Run golangci-lint efficiently on Go projects. Lint only changed code, fix v2 config issues, handle common warnings. Use when linting Go code, seeing golangci-lint errors, or user asks to "lint changed code", "lint PR", "fix lint errors".
+---
+
+# golangci-lint
+
+Efficient Go linting with golangci-lint.
+
+## Lint Changed Code Only
+
+```bash
+# Lint unstaged changes (or HEAD~ if no unstaged)
+golangci-lint run --new ./...
+
+# Lint from specific revision
+golangci-lint run --new-from-rev=HEAD~5 ./...
+
+# Lint from merge-base (ideal for PRs)
+golangci-lint run --new-from-merge-base=main ./...
+
+# Lint entire changed files (not just changed lines)
+golangci-lint run --new-from-rev=HEAD~5 --whole-files ./...
+```
+
+## golangci-lint v2 Config Migration
+
+Config format changed in v2. Common errors and fixes:
+
+| Error | Fix |
+|-------|-----|
+| `unsupported version of the configuration` | Add `version: "2"` at top |
+| `typecheck is not a linter` | Remove `typecheck` from enabled linters |
+| `unknown linters: 'gosimple'` | Remove `gosimple` (now part of `staticcheck`) |
+
+**Minimal v2 config** (`.golangci.yml`):
+
+```yaml
+version: "2"
+
+run:
+  timeout: 10m
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - errcheck
+    - govet
+    - staticcheck
+    - unused
+    - ineffassign
+    - gosec
+    - unconvert
+    - dupl
+    - goconst
+```
+
+## Common Suppressions
+
+### Ignore return value (errcheck)
+
+```go
+// Single line
+defer tp.Shutdown(ctx) //nolint:errcheck // reason
+
+// Function scope
+//nolint:errcheck
+func cleanup() { ... }
+```
+
+### Integer overflow (gosec G115)
+
+```go
+// Safe conversion (value won't overflow)
+otelutil.SetShopAttributes(ctx, int64(shop.Id), domain) //nolint:gosec // IDs won't overflow int64
+```
+
+### Deprecated package (staticcheck SA1019)
+
+```go
+//nolint:staticcheck // using deprecated for compatibility
+import "io/ioutil"
+```
+
+## Lint Specific Packages
+
+```bash
+# Single package
+golangci-lint run ./internal/otel/...
+
+# Multiple packages
+golangci-lint run ./internal/otel/... ./internal/invoke/...
+
+# Filter output for specific issues
+golangci-lint run ./... 2>&1 | grep -E "(otel|SetShop)"
+```
+
+## Quick Reference
+
+| Flag | Purpose |
+|------|---------|
+| `--new` | Only new issues (unstaged or HEAD~) |
+| `--new-from-rev=REV` | Only issues after git revision |
+| `--new-from-merge-base=BRANCH` | Only issues after merge-base |
+| `--whole-files` | Check entire changed files |
+| `--fix` | Auto-fix issues where possible |
+| `--fast` | Run only fast linters |
+
+## Workflow: PR Linting
+
+```bash
+# 1. Check what branch you're comparing against
+git log --oneline -5
+
+# 2. Lint only PR changes
+golangci-lint run --new-from-merge-base=main ./...
+
+# 3. If issues, fix and verify
+# ... make fixes ...
+golangci-lint run --new ./...  # verify fixes
+```
+
+## Workflow: Pre-commit
+
+```bash
+# Lint staged changes before commit
+golangci-lint run --new ./...
+```


### PR DESCRIPTION
## Summary
- Adds golangci-lint skill for efficient Go linting workflows
- Covers incremental linting with `--new` and `--new-from-merge-base` flags
- Documents v2 config migration and common `//nolint` patterns

## Test plan
- [ ] Install plugin with `/plugin install golangci-lint@aiocean-plugins`
- [ ] Verify skill loads correctly
- [ ] Test linting commands on a Go project

🤖 Generated with [Claude Code](https://claude.com/claude-code)