### PR TITLE
feat(aio-cocoindex): migrate vector storage to Qdrant

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -154,8 +154,8 @@
     {
       "name": "aio-cocoindex",
       "source": "./plugins/aio-cocoindex",
-      "description": "CocoIndex-based semantic search with auto language detection and tree-sitter code chunking. One project = one unified index. Zero-config: just set PROJECT_NAME and SOURCE_DIRS. Two skills: aio-cocoindex-setup (scaffold .cocoindex/) and aio-cocoindex (search and maintain).",
-      "version": "3.0.0",
+      "description": "CocoIndex-based semantic search with Qdrant vector storage, auto language detection and tree-sitter code chunking. One project = one unified index. Zero-config: just set PROJECT_NAME and SOURCE_DIRS. Two skills: aio-cocoindex-setup (scaffold .cocoindex/) and aio-cocoindex (search and maintain).",
+      "version": "4.0.0",
       "author": { "name": "aiocean" }
     },
     {

--- a/plugins/aio-cocoindex/.claude-plugin/plugin.json
+++ b/plugins/aio-cocoindex/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aio-cocoindex",
   "description": "CocoIndex-based document indexing with incremental processing and semantic search. Two skills: aio-cocoindex-setup (scaffold project-specific .cocoindex/ directory) and aio-cocoindex (search and maintain existing index).",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "author": {
     "name": "aiocean"
   }

--- a/plugins/aio-cocoindex/skills/aio-cocoindex-setup/SKILL.md
+++ b/plugins/aio-cocoindex/skills/aio-cocoindex-setup/SKILL.md
@@ -77,7 +77,8 @@ cat $BP/config.py
 
 Then write a customized version to `.cocoindex/config.py` with:
 - Correct `PROJECT_NAME`
-- Correct `DATABASE_URL` (ask user for their PostgreSQL host)
+- Correct `DATABASE_URL` (ask user for their PostgreSQL host — used for CocoIndex metadata only)
+- Correct `QDRANT_URL` (ask user for their Qdrant endpoint — used for vector storage)
 - Correct `EMBEDDING_API_TYPE` — `"local"` or `"gemini"` based on user choice
 - Correct `SOURCE_DIRS` — directories to index
 
@@ -98,6 +99,7 @@ Languages are auto-detected from file extensions. No need to configure collectio
 ```bash
 cat > .cocoindex/.env << 'EOF'
 COCOINDEX_DATABASE_URL=postgresql://cocoindex:cocoindex@<HOST>:5432/cocoindex
+COCOINDEX_QDRANT_URL=http://localhost:6334
 COCOINDEX_EMBEDDING_API_TYPE=local
 COCOINDEX_EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
 EOF
@@ -107,16 +109,24 @@ EOF
 ```bash
 cat > .cocoindex/.env << 'EOF'
 COCOINDEX_DATABASE_URL=postgresql://cocoindex:cocoindex@<HOST>:5432/cocoindex
+COCOINDEX_QDRANT_URL=http://localhost:6334
 COCOINDEX_EMBEDDING_API_TYPE=gemini
 COCOINDEX_EMBEDDING_MODEL=gemini-embedding-2-preview
 GEMINI_API_KEY=<user's API key>
 EOF
 ```
 
-Ask user for the PostgreSQL host. If they don't have one:
+**For Qdrant Cloud** (instead of local), set:
+```
+COCOINDEX_QDRANT_URL=https://xyz-example.cloud-region.cloud.qdrant.io:6334
+COCOINDEX_QDRANT_API_KEY=<your-qdrant-api-key>
+```
 
+Ask user for the PostgreSQL host (needed for CocoIndex metadata tracking) and Qdrant endpoint.
+
+If they don't have PostgreSQL:
 ```bash
-# Start PostgreSQL + pgvector via Docker
+# Start PostgreSQL via Docker (metadata only — no pgvector needed)
 docker run -d \
   --name cocoindex-postgres \
   --restart unless-stopped \
@@ -124,9 +134,18 @@ docker run -d \
   -e POSTGRES_PASSWORD=cocoindex \
   -e POSTGRES_DB=cocoindex \
   -p 5432:5432 \
-  pgvector/pgvector:pg17
+  postgres:17
+```
 
-docker exec cocoindex-postgres psql -U cocoindex -c "CREATE EXTENSION IF NOT EXISTS vector;"
+If they don't have Qdrant:
+```bash
+# Start Qdrant via Docker
+docker run -d \
+  --name cocoindex-qdrant \
+  --restart unless-stopped \
+  -p 6333:6333 \
+  -p 6334:6334 \
+  qdrant/qdrant
 ```
 
 ### Step 7: Install & Index
@@ -171,7 +190,7 @@ toml, json, html, css.
 
 | | Local (MiniLM-L6-v2) | Gemini (embedding-2-preview) |
 |---|---|---|
-| Dimension | 384 | 1536 (reduced from 3072 for HNSW compatibility) |
+| Dimension | 384 | 1536 (reduced from 3072 for efficiency) |
 | Quality | Good (English) | Excellent (multilingual) |
 | Cost | Free | ~$0.00025/1K tokens |
 | Speed | Fast (no network) | Slower (API calls) |
@@ -188,8 +207,9 @@ toml, json, html, css.
 | `pip install` fails with PEP 668 error | Use `python3 -m venv` — never install globally |
 | Closure captures wrong loop variable | `index.py` uses `_lang=lang` default arg — don't modify |
 | "UNEXPECTED key: embeddings.position_ids" | Harmless warning from sentence-transformers — ignore it |
-| Switching embedding model | Must re-index everything — vector dimensions and space are incompatible |
+| Switching embedding model | Must re-index everything — vector dimensions are incompatible. Delete Qdrant collections and re-run setup + update |
 | Gemini rate limits on large indexes | CocoIndex handles batching internally, but very large indexes (50K+ chunks) may need patience |
+| Qdrant connection refused | Qdrant container not running — check Docker. Default gRPC port is 6334 |
 | `GEMINI_API_KEY` from shell overrides `.env` | Boilerplate uses `load_dotenv(override=True)` to ensure `.env` takes precedence over shell env vars |
 | No languages detected | Check SOURCE_DIRS points to directories with supported file types |
 

--- a/plugins/aio-cocoindex/skills/aio-cocoindex-setup/boilerplate/config.py
+++ b/plugins/aio-cocoindex/skills/aio-cocoindex-setup/boilerplate/config.py
@@ -14,11 +14,15 @@ PROJECT_ROOT = os.getenv(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
 )
 
-# PostgreSQL connection (with pgvector extension)
+# PostgreSQL connection (CocoIndex internal metadata only — NOT for vectors)
 DATABASE_URL = os.getenv(
     "COCOINDEX_DATABASE_URL",
     "postgresql://cocoindex:cocoindex@localhost:5432/cocoindex",
 )
+
+# Qdrant connection (vector storage)
+QDRANT_URL = os.getenv("COCOINDEX_QDRANT_URL", "http://localhost:6334")
+QDRANT_API_KEY = os.getenv("COCOINDEX_QDRANT_API_KEY", "")
 
 # ============================================================
 # EMBEDDING CONFIGURATION

--- a/plugins/aio-cocoindex/skills/aio-cocoindex-setup/boilerplate/index.py
+++ b/plugins/aio-cocoindex/skills/aio-cocoindex-setup/boilerplate/index.py
@@ -29,12 +29,21 @@ load_dotenv(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env"), ov
 import cocoindex
 import config
 
+# Register Qdrant connection (used by all flows)
+qdrant_connection = cocoindex.add_auth_entry(
+    "qdrant",
+    cocoindex.targets.QdrantConnection(
+        grpc_url=config.QDRANT_URL,
+        **({"api_key": config.QDRANT_API_KEY} if config.QDRANT_API_KEY else {}),
+    ),
+)
+
 
 def _get_embed_spec():
     """Return the embedding function spec based on config."""
     if config.EMBEDDING_API_TYPE == "gemini":
         # output_dimension=1536: Gemini recommends 768/1536/3072.
-        # 1536 fits pgvector HNSW limit (max 2000 dims) while keeping quality.
+        # 1536 balances quality vs storage/compute cost.
         # NOTE: If CocoIndex batch API errors on task_type/output_dimension,
         # remove them — it's a CocoIndex compatibility issue, not Gemini's.
         return cocoindex.functions.EmbedText(
@@ -117,17 +126,14 @@ def build_flow(
                 embedding=chunk["embedding"],
             )
 
-    table_name = f"{config.PROJECT_NAME}_{language}"
+    collection_name = f"{config.PROJECT_NAME}_{language}"
     doc_embeddings.export(
-        table_name,
-        cocoindex.storages.Postgres(),
+        collection_name,
+        cocoindex.targets.Qdrant(
+            collection_name=collection_name,
+            connection=qdrant_connection,
+        ),
         primary_key_fields=["filename", "location"],
-        vector_indexes=[
-            cocoindex.VectorIndexDef(
-                field_name="embedding",
-                metric=cocoindex.VectorSimilarityMetric.COSINE_SIMILARITY,
-            )
-        ],
     )
 
 

--- a/plugins/aio-cocoindex/skills/aio-cocoindex-setup/boilerplate/query.py
+++ b/plugins/aio-cocoindex/skills/aio-cocoindex-setup/boilerplate/query.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Semantic search over CocoIndex-indexed project — DO NOT EDIT.
-Auto-discovers all indexed tables for the project and searches them together.
+Auto-discovers all indexed collections for the project and searches them together.
 
 Usage:
     python .cocoindex/query.py "search query"
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from dotenv import load_dotenv
 load_dotenv(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env"), override=True)
 
-import psycopg2
+from qdrant_client import QdrantClient
 
 import config
 
@@ -43,95 +43,76 @@ def _embed_query(text: str) -> list[float]:
         return model.encode(text).tolist()
 
 
-def get_connection():
-    return psycopg2.connect(config.DATABASE_URL)
+def get_client():
+    kwargs = {"url": config.QDRANT_URL}
+    if config.QDRANT_API_KEY:
+        kwargs["api_key"] = config.QDRANT_API_KEY
+    return QdrantClient(**kwargs)
 
 
-def get_tables():
-    """Auto-discover all tables for this project.
+def get_collections():
+    """Auto-discover all Qdrant collections for this project.
 
-    CocoIndex naming convention:
-        Flow name: {ProjectTitle}{LanguageTitle}
-        Export name: {project}_{language}
-        Actual table: {flowname_lowercase}__{project}_{language}
-
-    Example: PROJECT_NAME="compass", language="python"
-        -> Flow: CompassPython
-        -> Table: compasspython__compass_python
+    CocoIndex naming convention: {project}_{language}
+    Example: PROJECT_NAME="compass", language="python" -> "compass_python"
     """
-    conn = get_connection()
-    cur = conn.cursor()
-    pattern = f"%\\_\\_{config.PROJECT_NAME}\\_%"
-    cur.execute("""
-        SELECT tablename FROM pg_tables
-        WHERE schemaname = 'public'
-        AND tablename LIKE %s
-        AND tablename NOT LIKE '%%\\_tracking'
-    """, (pattern,))
-    tables = [row[0] for row in cur.fetchall()]
-    conn.close()
-    return tables
+    client = get_client()
+    all_collections = client.get_collections().collections
+    prefix = f"{config.PROJECT_NAME}_"
+    return [c.name for c in all_collections if c.name.startswith(prefix)]
 
 
-def _table_language(table: str) -> str:
-    """Extract language name from table name."""
-    separator = f"__{config.PROJECT_NAME}_"
-    if separator in table:
-        return table.split(separator, 1)[1]
-    return table
+def _collection_language(collection: str) -> str:
+    """Extract language name from collection name."""
+    prefix = f"{config.PROJECT_NAME}_"
+    if collection.startswith(prefix):
+        return collection[len(prefix):]
+    return collection
 
 
 def get_status():
-    """Check index status — row counts per language."""
-    conn = get_connection()
-    cur = conn.cursor()
-    tables = get_tables()
+    """Check index status — point counts per language."""
+    client = get_client()
+    collections = get_collections()
     results = {}
-    for table in tables:
-        lang = _table_language(table)
+    for coll in collections:
+        lang = _collection_language(coll)
         try:
-            cur.execute(f'SELECT count(*) FROM "{table}"')
-            results[lang] = cur.fetchone()[0]
+            info = client.get_collection(coll)
+            results[lang] = info.points_count
         except Exception:
-            conn.rollback()
             results[lang] = 0
-    conn.close()
     return results
 
 
 def query_similar(question: str, top_k: int = 5):
-    """Search all project tables by semantic similarity."""
+    """Search all project collections by semantic similarity."""
     query_embedding = _embed_query(question)
 
-    conn = get_connection()
-    cur = conn.cursor()
-
-    tables = get_tables()
+    client = get_client()
+    collections = get_collections()
     all_results = []
-    for table in tables:
-        lang = _table_language(table)
+
+    for coll in collections:
+        lang = _collection_language(coll)
         try:
-            cur.execute(
-                f"""
-                SELECT filename, text, 1 - (embedding <=> %s::vector) as similarity
-                FROM "{table}"
-                ORDER BY embedding <=> %s::vector
-                LIMIT %s
-                """,
-                (str(query_embedding), str(query_embedding), top_k),
-            )
-            for row in cur.fetchall():
+            hits = client.query_points(
+                collection_name=coll,
+                query=query_embedding,
+                limit=top_k,
+                with_payload=True,
+            ).points
+            for hit in hits:
+                payload = hit.payload or {}
                 all_results.append({
                     "language": lang,
-                    "filename": row[0],
-                    "text": row[1],
-                    "similarity": round(float(row[2]), 4),
+                    "filename": payload.get("filename", ""),
+                    "text": payload.get("text", ""),
+                    "similarity": round(float(hit.score), 4),
                 })
         except Exception as e:
-            conn.rollback()
-            print(f"Warning: Could not query {table}: {e}", file=sys.stderr)
+            print(f"Warning: Could not query {coll}: {e}", file=sys.stderr)
 
-    conn.close()
     all_results.sort(key=lambda x: x["similarity"], reverse=True)
     return all_results[:top_k]
 

--- a/plugins/aio-cocoindex/skills/aio-cocoindex-setup/boilerplate/requirements.txt
+++ b/plugins/aio-cocoindex/skills/aio-cocoindex-setup/boilerplate/requirements.txt
@@ -1,5 +1,5 @@
 cocoindex[embeddings]>=0.1.0
-psycopg2-binary>=2.9.0
+qdrant-client>=1.9.0
 python-dotenv>=1.0.0
 sentence-transformers>=2.0.0
 google-genai>=1.0.0

--- a/plugins/aio-cocoindex/skills/aio-cocoindex/SKILL.md
+++ b/plugins/aio-cocoindex/skills/aio-cocoindex/SKILL.md
@@ -118,13 +118,14 @@ grep EMBEDDING_API_TYPE .cocoindex/config.py .cocoindex/.env
 | Problem | Solution |
 |---------|----------|
 | `.cocoindex/` not found | Run `aio-cocoindex-setup` skill first |
-| Connection refused | PostgreSQL container not running — check Docker |
+| Connection refused (Postgres) | PostgreSQL container not running — needed for CocoIndex metadata |
+| Connection refused (Qdrant) | Qdrant container not running — check Docker (gRPC port 6334) |
 | 0 chunks after update | Make sure to use `update` subcommand, not `server` |
 | Slow first run (local) | Model download (~90MB) + bulk embedding — subsequent runs are incremental |
 | Slow first run (Gemini) | API calls for all chunks — subsequent runs are incremental |
 | venv missing | `python3 -m venv .venv-cocoindex && .venv-cocoindex/bin/pip install -r .cocoindex/requirements.txt` |
 | `GEMINI_API_KEY` not set | Add to `.cocoindex/.env` — required for Gemini mode |
-| Dimension mismatch error | Switched model without re-index — run `setup` then `update --full-reprocess` |
+| Dimension mismatch error | Switched model without re-index — delete Qdrant collections, run `setup` then `update --full-reprocess` |
 | No languages detected | Check `SOURCE_DIRS` in config.py points to directories with supported file types |
 
 ## Adding New Source Directories
@@ -141,14 +142,16 @@ Then re-run setup and index:
 .venv-cocoindex/bin/cocoindex -e .cocoindex/.env update .cocoindex/index.py -f
 ```
 
-## Direct Database Access
+## Direct Qdrant Access
 
-Read `config.py` to find the database URL and project name. Tables are auto-named as `{project}{language}__{project}_{language}`:
+Read `config.py` to find the Qdrant URL and project name. Collections are named `{project}_{language}`:
 
 ```bash
-# Connect
-docker exec -it cocoindex-postgres psql -U cocoindex
+# List collections via REST API
+curl http://localhost:6333/collections
 
-# Row counts
-SELECT tablename, (SELECT count(*) FROM <tablename>) FROM pg_tables WHERE schemaname = 'public' AND tablename NOT LIKE '%tracking%' AND tablename != 'cocoindex_setup_metadata';
+# Get collection info
+curl http://localhost:6333/collections/{project}_{language}
+
+# Or use Qdrant Web UI at http://localhost:6333/dashboard
 ```


### PR DESCRIPTION
## Summary
- Replace PostgreSQL+pgvector with **Qdrant** for vector storage (CocoIndex `targets.Qdrant`)
- PostgreSQL retained for CocoIndex internal metadata tracking only (no pgvector extension needed)
- Rewrite `query.py` to use `qdrant-client` instead of `psycopg2` for similarity search
- Update Docker setup: separate `postgres:17` + `qdrant/qdrant` containers
- Bump to **v4.0.0** (breaking change — existing pgvector indexes incompatible)

## Test plan
- [ ] Run `docker run -d -p 6333:6333 -p 6334:6334 qdrant/qdrant` and verify Qdrant starts
- [ ] Scaffold a new `.cocoindex/` directory using the setup skill
- [ ] Run `cocoindex setup` and `cocoindex update` — verify collections created in Qdrant
- [ ] Run `query.py --status` — verify point counts per language
- [ ] Run `query.py "test query"` — verify semantic search returns results
- [ ] Verify Qdrant Web UI accessible at `http://localhost:6333/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)