### PR TITLE
fix(aio-reflect): fix 8 bugs, bump to v1.1.0

### DIFF
--- a/plugins/aio-reflect/.claude-plugin/plugin.json
+++ b/plugins/aio-reflect/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aio-reflect",
   "description": "Learn from Claude Code sessions to extract reusable knowledge. Analyzes corrections, preferences, and technical discoveries to build CLAUDE.md rules and new skills.",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "author": { "name": "aiocean" },
   "license": "MIT"
 }

--- a/plugins/aio-reflect/skills/aio-reflect/SKILL.md
+++ b/plugins/aio-reflect/skills/aio-reflect/SKILL.md
@@ -20,6 +20,8 @@ description: This skill should be used when the user asks to "reflect on session
 Before calling any script, resolve the scripts directory (version may vary):
 ```bash
 RF="$(ls -d ~/.claude/plugins/cache/aiocean-plugins/aio-reflect/*/skills/aio-reflect/scripts 2>/dev/null | sort -V | tail -1)"
+MEMORY="$HOME/.claude/aio-reflect/memory"
+mkdir -p "$MEMORY/diary" "$MEMORY/reflections"
 ```
 
 Then call scripts as `bun run $RF/script-name`:
@@ -45,9 +47,15 @@ bun run $RF/extract-session.ts <project-path> --last 5 --json
    ```bash
    bun run $RF/get-project-path.ts <path> --check
    ```
+3.5. (Optional) List all projects with sessions:
+   ```bash
+   bun run $RF/project-tree.ts --stats
+   ```
 4. Check for unprocessed sessions:
    ```bash
-   # Compare sessions in project folder with memory/processed.json
+   # List sessions with stats to identify unprocessed ones
+   bun run $RF/extract-session.ts <project-path> --stats-only
+   # Then compare session IDs against $MEMORY/processed.json
    ```
 5. Load existing CLAUDE.md rules (for violation detection)
 6. Ask user how many sessions to analyze (default: 5)
@@ -230,7 +238,7 @@ For new rules:
 
 **Step 4: Mark sessions as processed**
 
-Update `memory/processed.json`:
+Update `$MEMORY/processed.json`:
 
 ```json
 {
@@ -246,7 +254,7 @@ Update `memory/processed.json`:
 
 **Step 5: Write diary entry (optional)**
 
-If user wants, save reflection to `memory/diary/YYYY-MM-DD-reflection.md`
+If user wants, save reflection to `$MEMORY/diary/YYYY-MM-DD-reflection.md`
 
 ## Skill Template
 
@@ -315,7 +323,7 @@ date: [YYYY-MM-DD]
 **Save locations:**
 
 - Project-specific: `.claude/skills/[name]/SKILL.md`
-- User-wide: `~/.claude/plugins/cache/aiocean-plugins/[name]/*/skills/[name]/SKILL.md`
+- User-wide: `~/.claude/skills/[name]/SKILL.md`
 
 ## Scripts Reference
 
@@ -327,10 +335,10 @@ date: [YYYY-MM-DD]
 
 ## Memory Directory
 
-Located in the skill's `memory/` folder:
+Located at `~/.claude/aio-reflect/memory/` (stable across upgrades, not inside versioned cache):
 
 ```
-memory/
+~/.claude/aio-reflect/memory/
 ├── diary/              # Reflection summaries
 ├── reflections/        # Session-specific notes
 └── processed.json      # Tracking analyzed sessions

--- a/plugins/aio-reflect/skills/aio-reflect/scripts/extract-session.ts
+++ b/plugins/aio-reflect/skills/aio-reflect/scripts/extract-session.ts
@@ -44,7 +44,12 @@ function resolveSessionFolder(inputPath: string): string {
   // Try partial match for subdirectories
   if (existsSync(PROJECTS_DIR)) {
     const folders = readdirSync(PROJECTS_DIR);
-    const match = folders.find((f) => folderName.startsWith(f) || f.startsWith(folderName));
+    const match = folders.find((f) => {
+      if (f === folderName) return true;
+      if (folderName.startsWith(f + "-")) return true;
+      if (f.startsWith(folderName + "-")) return true;
+      return false;
+    });
     if (match) {
       return join(PROJECTS_DIR, match);
     }
@@ -86,9 +91,6 @@ interface DiaryEntry {
   workDone: string[];
   filesModified: string[];
   toolsUsedSummary: string;
-  keyDecisions: string[];
-  challenges: string[];
-  outcomes: string[];
 }
 
 interface Session {
@@ -123,8 +125,6 @@ function parseSessionFile(filePath: string): Session | null {
   let sessionId = "";
   let project = "";
   let gitBranch = "";
-  const pendingToolResults = new Map<string, string>();
-
   for (const line of lines) {
     try {
       const entry: RawEntry = JSON.parse(line);
@@ -145,7 +145,7 @@ function parseSessionFile(filePath: string): Session | null {
       gitBranch = entry.gitBranch || gitBranch;
 
       if (entry.type === "user") {
-        const parsed = parseUserMessage(entry.message?.content, pendingToolResults);
+        const parsed = parseUserMessage(entry.message?.content);
         if (parsed.content || parsed.toolResults.length > 0) {
           // If this is a tool result, attach it to the previous assistant turn
           if (parsed.toolResults.length > 0 && turns.length > 0) {
@@ -220,7 +220,6 @@ function parseSessionFile(filePath: string): Session | null {
 
 function parseUserMessage(
   content: unknown,
-  _pendingResults: Map<string, string>,
 ): { content: string; toolResults: { id: string; content: string }[] } {
   const toolResults: { id: string; content: string }[] = [];
   let textContent = "";
@@ -409,9 +408,6 @@ function generateDiary(turns: Turn[], stats: SessionStats): DiaryEntry {
     workDone: workDone.slice(0, 10),
     filesModified: [...filesModified],
     toolsUsedSummary: topTools,
-    keyDecisions: [], // To be filled by AI analysis
-    challenges: [], // To be filled by AI analysis
-    outcomes: [], // To be filled by AI analysis
   };
 }
 
@@ -446,6 +442,10 @@ function formatSession(
     }
   }
 
+  if (options.diaryOnly) {
+    return lines.join("\n");
+  }
+
   // Stats summary
   lines.push(`\n## Stats`);
   lines.push(`- Turns: ${session.stats.userTurns} user, ${session.stats.assistantTurns} assistant`);
@@ -467,7 +467,7 @@ function formatSession(
     lines.push(`- Agents: ${session.stats.agentsUsed.join(", ")}`);
   }
 
-  if (options.statsOnly || options.diaryOnly) {
+  if (options.statsOnly) {
     return lines.join("\n");
   }
 
@@ -506,7 +506,7 @@ function formatSession(
           // Show result if available (truncated for readability)
           if (tool.result) {
             const resultPreview =
-              tool.result.length > 500 ? tool.result.slice(0, 500) + "..." : tool.result;
+              tool.result.length > 2000 ? tool.result.slice(0, 2000) + "..." : tool.result;
             lines.push(`Result: ${resultPreview}`);
           }
           lines.push("");

--- a/plugins/aio-reflect/skills/aio-reflect/scripts/get-project-path.ts
+++ b/plugins/aio-reflect/skills/aio-reflect/scripts/get-project-path.ts
@@ -40,7 +40,13 @@ function findProjectFolder(realPath: string): string | null {
   // Try to find partial match (for subdirectories)
   if (existsSync(PROJECTS_DIR)) {
     const folders = readdirSync(PROJECTS_DIR);
-    const match = folders.find((f) => expectedFolder.startsWith(f) || f.startsWith(expectedFolder));
+    const match = folders.find((f) => {
+      if (f === expectedFolder) return true;
+      // Only match if prefix ends at a '-' boundary (encoded path separator)
+      if (expectedFolder.startsWith(f + "-")) return true;
+      if (f.startsWith(expectedFolder + "-")) return true;
+      return false;
+    });
     if (match) {
       return join(PROJECTS_DIR, match);
     }

--- a/plugins/aio-reflect/skills/aio-reflect/scripts/project-tree.ts
+++ b/plugins/aio-reflect/skills/aio-reflect/scripts/project-tree.ts
@@ -22,6 +22,11 @@ function folderToPath(folderName: string): string {
   // Convert folder name back to path
   // Pattern: double dash = /. (hidden dir), single dash = /
   // e.g., -Users-username--claude → /Users/username/.claude
+  //
+  // LIMITATION: This conversion is lossy for paths containing hyphens.
+  // e.g., -Users-name-my-project cannot be distinguished from
+  //       -Users-name-my/project vs /Users/name/my-project
+  // If the decoded path doesn't exist, use folderName as a fallback hint.
 
   let path = folderName
     // Double dash means hidden directory: /.
@@ -37,7 +42,7 @@ function getSessionCount(projectFolder: string): number {
   try {
     const entries = readdirSync(fullPath);
     // Count .jsonl files (sessions)
-    return entries.filter((e) => e.endsWith(".jsonl")).length;
+    return entries.filter((e) => e.endsWith(".jsonl") && !e.startsWith("agent-")).length;
   } catch {
     return 0;
   }
@@ -111,8 +116,9 @@ function printTree(projects: ProjectInfo[], showStats: boolean) {
       const stats = showStats
         ? ` (${p.sessionCount} sessions, ${p.lastModified.toLocaleDateString()})`
         : "";
+      const folderHint = !p.exists ? ` (folder: ${p.folderName})` : "";
 
-      console.log(`   ${prefix}${status} ${subPath || "(root)"}${stats}`);
+      console.log(`   ${prefix}${status} ${subPath || "(root)"}${stats}${folderHint}`);
     }
     console.log("");
   }


### PR DESCRIPTION
## Summary

- Fix `project-tree.ts` inflated session counts (agent replays were counted)
- Fix `extract-session.ts` unused parameter, tool result truncation (500→2000 chars), `--diary` flag showing stats, dead code removal
- Fix `get-project-path.ts` partial match falsely matching projects with shared path prefixes
- Fix `SKILL.md` memory path to survive version upgrades (`~/.claude/aio-reflect/memory/`), add concrete commands in Phase 1, fix wrong skill save path

## Test plan

- [x] `get-project-path --check` finds project correctly
- [x] `project-tree --stats` shows accurate session counts without agent replays
- [x] `extract-session --diary` returns diary only (no stats block)
- [x] `extract-session --stats-only` returns summary + stats only (no conversation)
- [x] All scripts run without errors via `bun run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)