### PR TITLE
feat(aio-epub-translate): add HTML preservation rule (v2.2.0)

### DIFF
--- a/plugins/aio-epub-translate/.claude-plugin/plugin.json
+++ b/plugins/aio-epub-translate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aio-epub-translate",
   "description": "AI-driven EPUB translation using jread CLI. Unpack EPUBs, mark content, translate with full context awareness, maintain glossaries, and export bilingual or clean EPUBs. Claude acts as translation director — reading full chapters, building terminology databases, and ensuring consistency across the entire book.",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": { "name": "aiocean" },
   "repository": "https://github.com/aiocean/claude-plugins",
   "license": "MIT"

--- a/plugins/aio-epub-translate/skills/aio-epub-translate/SKILL.md
+++ b/plugins/aio-epub-translate/skills/aio-epub-translate/SKILL.md
@@ -78,6 +78,13 @@ Translate all items in the batch simultaneously — not one at a time. This allo
 - Consistent pronoun choices
 - Natural flow between consecutive sentences
 
+**HTML Preservation Rule:** The `text` field from `jread list` contains innerHTML — it may include inline tags like `<em>`, `<strong>`, `<a href="...">`, `<span>`, etc. You MUST preserve all HTML tags in the translation. Only translate the visible text content, never alter or remove tags, attributes, or structure.
+
+Example:
+- Source: `He was <em>absolutely</em> certain.`
+- Correct: `Anh ta <em>hoàn toàn</em> chắc chắn.`
+- Wrong: `Anh ta hoàn toàn chắc chắn.` ← lost `<em>`
+
 Write translations:
 ```bash
 jread set workspace/OEBPS/Text/chapter0001.html <id> "<translation>" --lang=vi


### PR DESCRIPTION
## Summary
- Add **HTML Preservation Rule** to Step 4 of the translation loop
- Clarifies that `jread list` returns innerHTML (not plain text) in the `text` field
- Instructs Claude to keep all inline tags (`<em>`, `<strong>`, `<a>`, `<span>`) when writing translations
- Includes correct/wrong examples for clarity
- Bumps version `2.1.0` → `2.2.0`

## Test plan
- [ ] Run `jread list` on a chapter with inline HTML (e.g. `<em>`) and verify Claude preserves tags in translation output
- [ ] Pack epub and confirm inline formatting is intact in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)