### PR TITLE
feat: add circuit breaker and re-anchoring protocols

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -187,8 +187,8 @@
     {
       "name": "aio-debug",
       "source": "./plugins/aio-debug",
-      "description": "Systematic debug & fix orchestrator. Four-phase pipeline: codebase context → root cause investigation → minimal fix → code review validation.",
-      "version": "2.2.0",
+      "description": "Systematic debug & fix orchestrator. Four-phase pipeline: codebase context → root cause investigation → minimal fix → code review validation. Circuit breaker escalation after 3 failed attempts.",
+      "version": "2.3.0",
       "author": {
         "name": "aiocean"
       }
@@ -223,8 +223,8 @@
     {
       "name": "aio-deep-plan",
       "source": "./plugins/aio-deep-plan",
-      "description": "Deep planning toolkit combining GitNexus knowledge graph and LSP for thorough pre-coding analysis. Five skills: discover (find relevant code), map (structural analysis), snapshot (baseline), plan (implementation planning), review (post-implementation check).",
-      "version": "3.2.0",
+      "description": "Deep planning toolkit combining GitNexus knowledge graph and LSP for thorough pre-coding analysis. Five skills: discover (find relevant code), map (structural analysis), snapshot (baseline), plan (implementation planning with re-anchoring protocol), review (post-implementation check).",
+      "version": "3.3.0",
       "author": {
         "name": "aiocean"
       }

--- a/plugins/aio-debug/.claude-plugin/plugin.json
+++ b/plugins/aio-debug/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aio-debug",
   "description": "Systematic debug & fix orchestrator. Four-phase pipeline: codebase context → root cause investigation → minimal fix → code review validation.",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": { "name": "aiocean" },
   "repository": "https://github.com/aiocean/claude-plugins",
   "license": "MIT"

--- a/plugins/aio-debug/skills/aio-debug/SKILL.md
+++ b/plugins/aio-debug/skills/aio-debug/SKILL.md
@@ -53,8 +53,27 @@ With codebase context established, apply systematic debugging rigor:
 **Critical constraints**:
 - Never guess. Gather evidence first
 - One change at a time. Never shotgun multiple fixes
-- If 3+ fix attempts fail, question the architecture
 - Compare broken code against working examples in the same codebase
+
+### Circuit Breaker — 3 Strikes Rule
+
+Track each fix attempt explicitly (attempt 1, attempt 2, attempt 3). After **3 failed fix attempts**, STOP and escalate:
+
+1. **Declare circuit breaker** — announce: "Circuit breaker triggered: 3 fix attempts failed. Stopping to reassess."
+2. **Summarize all 3 attempts**: what was tried, what evidence was gathered, why each failed
+3. **Re-anchor** — re-read the original bug report and all Phase 1-2 evidence from scratch. Fresh eyes after reset.
+4. **Question the architecture**:
+   - Is the root cause actually in this layer, or is it a design flaw one level up?
+   - Are we fighting the framework/library instead of working with it?
+   - Is there a simpler approach that sidesteps the problem entirely?
+   - Should this component be restructured rather than patched?
+5. **Present options to the user**:
+   - Option A: Redesign the affected component (describe the approach)
+   - Option B: Work around with explicit trade-offs (describe them)
+   - Option C: Escalate to a human domain expert
+6. **Do NOT attempt a 4th fix** without user approval of a fundamentally different approach
+
+A circuit breaker is not failure — it prevents wasted time and regression-inducing guesses. The best debuggers know when to stop patching and start rethinking.
 
 **Exit criteria**: Confirmed root cause with evidence. Single, specific fix identified.
 

--- a/plugins/aio-debug/skills/aio-debug/references/orchestration-details.md
+++ b/plugins/aio-debug/skills/aio-debug/references/orchestration-details.md
@@ -45,6 +45,53 @@ Phase 4 (review) is complete when:
 - All critical issues from review are addressed
 - The fix is verified to not introduce new problems
 
+## Circuit Breaker — Detailed Protocol
+
+The circuit breaker is the most important safety mechanism in debugging. It prevents the "just one more try" trap that leads to hours of wasted effort and regression-introducing patches.
+
+### How to Track Attempts
+
+Maintain an explicit counter. After each failed Phase 3 attempt:
+
+```
+Attempt 1/3: [What was tried] → [Why it failed]
+Attempt 2/3: [What was tried] → [Why it failed]
+Attempt 3/3: [What was tried] → [Why it failed]
+⚡ CIRCUIT BREAKER TRIGGERED
+```
+
+A "failed attempt" means:
+- The fix didn't resolve the original bug
+- The fix resolved the bug but introduced new failures
+- The fix resolved some symptoms but not all
+- The fix required additional "patches on patches" to work
+
+A "failed attempt" does NOT mean:
+- A test that was supposed to fail did fail (that's TDD RED phase, not a fix attempt)
+- You discovered more information and refined your hypothesis (that's still Phase 2)
+
+### Re-anchor After Circuit Breaker
+
+When the circuit breaker triggers, perform a full context reset:
+
+1. **Re-read the original bug report** — what did the user actually say? Not your interpretation.
+2. **Re-read Phase 1 evidence** — what files, what data flow, what dependencies?
+3. **Re-read Phase 2 evidence** — what hypotheses were tested, what was ruled out?
+4. **List what you know for certain** (observed facts, not interpretations)
+5. **List what you assumed** — challenge each assumption
+
+This fresh-eyes review often reveals the root cause was misidentified. The fix attempts failed not because the fix was wrong, but because the diagnosis was wrong.
+
+### Architecture Questions Checklist
+
+When questioning the architecture after circuit breaker:
+
+- [ ] Is the bug in the right layer? (e.g., fixing frontend when the issue is backend validation)
+- [ ] Is the abstraction appropriate? (e.g., fighting a framework's design instead of using its intended pattern)
+- [ ] Is there a simpler design? (e.g., the component does too much and should be split)
+- [ ] Is there a known pattern for this? (search codebase for similar solved problems)
+- [ ] Would a different approach sidestep the problem entirely?
+
 ## Edge Cases
 
 ### Bug Cannot Be Reproduced

--- a/plugins/aio-deep-plan/.claude-plugin/plugin.json
+++ b/plugins/aio-deep-plan/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aio-deep-plan",
   "description": "Deep planning toolkit combining GitNexus hybrid search/knowledge graph and LSP for thorough pre-coding analysis. Five skills: discover (find relevant code), map (structural analysis), snapshot (baseline), plan (implementation planning), review (post-implementation check).",
-  "version": "2.2.0",
+  "version": "3.3.0",
   "author": { "name": "aiocean" },
   "repository": "https://github.com/aiocean/claude-plugins",
   "license": "MIT"

--- a/plugins/aio-deep-plan/skills/plan/SKILL.md
+++ b/plugins/aio-deep-plan/skills/plan/SKILL.md
@@ -112,6 +112,23 @@ For both automated strategies, the plan transitions through:
       → /superpowers:finishing-a-development-branch (wrap up)
 ```
 
+### Re-anchoring Protocol
+
+**Before starting each task** in the plan, re-anchor to prevent context drift and scope creep:
+
+1. **Re-read the plan** — go back to the Step 4 plan document and re-read the current task's specification (file path, changes, reason)
+2. **Check scope** — ask: "Does what I'm about to do match exactly what the plan says?" If you've drifted into adjacent concerns, stop and refocus
+3. **Verify assumptions** — if significant time has passed or multiple tasks are done, re-run `context(file)` on the file about to be changed to catch any changes from prior tasks
+4. **No unplanned changes** — if you discover something that needs fixing but is NOT in the plan, document it as a follow-up item in the "NOT Doing" section. Do not act on it.
+
+**When to re-anchor** (mandatory):
+- Before each numbered task in the Changes section
+- After any interruption or context switch
+- After a subagent returns results (verify it stayed on-plan)
+- When you catch yourself thinking "while I'm here, I should also..."
+
+Re-anchoring adds ~10 seconds per task but prevents the #1 cause of plan failure: gradual scope creep where each task drifts slightly until the final result doesn't match the original intent.
+
 ## Principles
 
 - Each business logic exists in ONE place only (SSOT)


### PR DESCRIPTION
## Summary

- **aio-debug (2.3.0)**: Add **Circuit Breaker — 3 Strikes Rule** — after 3 failed fix attempts, force stop and escalate with architecture questioning, re-anchoring, and user options
- **aio-deep-plan (3.3.0)**: Add **Re-anchoring Protocol** — mandatory re-read of plan specs before each task to prevent context drift and scope creep

Both patterns inspired by ecosystem research (#12):
- Circuit Breaker from [obra/superpowers](https://github.com/obra/superpowers) systematic-debugging skill
- Re-anchoring from [gmickel/Flow-Next](https://github.com/gmickel/gmickel-claude-marketplace) `.flow/` spec re-reading pattern

## Changes

### aio-debug
- `SKILL.md`: Replace one-liner "If 3+ fix attempts fail" with full Circuit Breaker section (6-step escalation protocol)
- `references/orchestration-details.md`: Add detailed protocol — attempt tracking format, "failed attempt" definition, re-anchor process, architecture questions checklist

### aio-deep-plan  
- `skills/plan/SKILL.md`: Add Re-anchoring Protocol after Step 6 — 4 re-anchor steps + 4 mandatory trigger points

### Registry
- `marketplace.json`: Version bumps + updated descriptions

## Test plan

- [ ] Install updated aio-debug plugin, trigger debugging on a complex bug, verify circuit breaker activates after 3 failed attempts
- [ ] Install updated aio-deep-plan plugin, run `/plan` on a multi-file feature, verify re-anchoring prompts appear before each task
- [ ] Verify marketplace.json versions match plugin.json versions

https://claude.ai/code/session_01NKoWZsx1cxozG9Ho3reDAv