### PR TITLE
feat: add CLI fallback docs for aio-jira plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -144,7 +144,7 @@
       "name": "aio-jira",
       "source": "./plugins/aio-jira",
       "description": "Jira operations through MCP tools. Issue management, sprint tracking, workflow transitions, comments, JQL search, and development information. Auto-installs jira-mcp server if missing.",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "author": {
         "name": "aiocean"
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A Claude Code plugin marketplace (`aiocean/claude-plugins`) containing 13 independent plugins. Users install via:
+A Claude Code plugin marketplace (`aiocean/claude-plugins`) containing 35+ independent plugins. Users install via:
 ```bash
 /plugin marketplace add aiocean/claude-plugins
 /plugin install <plugin-name>@aiocean-plugins
@@ -48,9 +48,10 @@ plugins/{plugin-name}/
 
 ## Plugin Categories
 
-- **Script-based** (worktree, remove-bg, claude-manager, ios-device-debug, youtube, golangci-lint): Shell/Python/TS scripts that execute actions
-- **Knowledge/Reference** (mental-models, monitoring, neobrutalism, react-minimal-effects, gherkin-refine): Documentation-only skills that provide frameworks and patterns
-- **Hybrid** (reflect, epub-packing, bun-fullstack-setup): Scripts + documentation
+- **Script-based** (worktree, ios-device-debug, youtube, claude-manager, install, feedback): Shell/Python/TS scripts that execute actions
+- **Knowledge/Reference** (mental-models, monitoring, neobrutalism, react-minimal-effects, gherkin-refine, xstate, tui, golang-mastery): Documentation-only skills that provide frameworks and patterns
+- **Hybrid** (reflect, epub-packing, bun-fullstack-setup, codebase-oracle, deep-plan, debug, code-review): Scripts + documentation
+- **MCP Integration** (jira, github, gitlab, confluence, google-workspace, x, tanca, rag-kit, research-kit, browser-cookie): Thin wrappers around MCP servers
 
 ## Adding a New Plugin
 
@@ -59,6 +60,8 @@ plugins/{plugin-name}/
 3. Add scripts/references as needed
 4. Register in `.claude-plugin/marketplace.json`
 5. Add description to `README.md`
+6. Update `docs/index.html` to include the new plugin
+7. Run `bash scripts/validate-marketplace.sh` to verify everything is correct
 
 ## SKILL.md Frontmatter Format
 
@@ -76,3 +79,11 @@ The `description` field is how Claude discovers and triggers the skill — inclu
 ## No Build System
 
 No package.json, no build step, no tests. Plugins are standalone directories of markdown and scripts. Shell scripts use `#!/bin/bash`. TypeScript scripts run via `bun`.
+
+## Commit Conventions
+
+Use conventional commits: `feat:`, `fix:`, `chore:`, `docs:` prefixes (e.g., `feat: add aio-new-plugin`).
+
+## Validation
+
+Run `bash scripts/validate-marketplace.sh` before considering any plugin work done. It checks plugin.json fields, folder naming, SKILL.md frontmatter, script existence, marketplace registration, and version sync.

--- a/plugins/aio-jira/.claude-plugin/plugin.json
+++ b/plugins/aio-jira/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aio-jira",
   "description": "Jira operations through MCP tools. Issue management, sprint tracking, workflow transitions, comments, JQL search, and development information. Auto-installs jira-mcp server if missing.",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "author": "aiocean"
 }

--- a/plugins/aio-jira/skills/aio-jira/SKILL.md
+++ b/plugins/aio-jira/skills/aio-jira/SKILL.md
@@ -11,6 +11,7 @@ Jira operations through MCP tools. Depends on [nguyenvanduocit/jira-mcp](https:/
 
 - Go: !`which go 2>/dev/null || echo "NOT INSTALLED"`
 - jira-mcp: !`which jira-mcp 2>/dev/null || echo "NOT INSTALLED"`
+- jira-cli: !`which jira-cli 2>/dev/null || echo "NOT INSTALLED"`
 - ATLASSIAN_HOST: !`echo ${ATLASSIAN_HOST:-NOT SET}`
 - ATLASSIAN_EMAIL: !`echo ${ATLASSIAN_EMAIL:-NOT SET}`
 - ATLASSIAN_TOKEN: !`[ -n "$ATLASSIAN_TOKEN" ] && echo "SET" || echo "NOT SET"`
@@ -20,6 +21,7 @@ Jira operations through MCP tools. Depends on [nguyenvanduocit/jira-mcp](https:/
 
 ```bash
 go install github.com/nguyenvanduocit/jira-mcp@latest
+go install github.com/nguyenvanduocit/jira-mcp/cmd/jira-cli@latest
 ```
 
 Docker alternative (if Go not available):
@@ -127,6 +129,35 @@ jira_list_project_versions(project_key: "PROJ")
 jira_get_version(version_id: "10042")
 jira_list_statuses(project_key: "PROJ")
 ```
+
+## CLI (fallback if MCP not configured)
+
+```bash
+jira-cli get-issue --issue-key PROJ-123 --env .env
+jira-cli search-issues --jql "project = PROJ AND status = 'In Progress'" --env .env
+jira-cli create-issue --project-key PROJ --summary "Bug title" --issue-type Bug --env .env
+jira-cli create-child-issue --parent-issue-key PROJ-100 --summary "Subtask" --env .env
+jira-cli update-issue --issue-key PROJ-123 --summary "Updated title" --env .env
+jira-cli delete-issue --issue-key PROJ-123 --env .env
+jira-cli list-issue-types --project-key PROJ --env .env
+jira-cli get-active-sprint --project-key PROJ --env .env
+jira-cli list-sprints --project-key PROJ --env .env
+jira-cli search-sprint --name "Sprint 23" --project-key PROJ --env .env
+jira-cli add-comment --issue-key PROJ-123 --comment "Fixed in PR #456" --env .env
+jira-cli get-comments --issue-key PROJ-123 --env .env
+jira-cli get-transitions --issue-key PROJ-123 --env .env
+jira-cli transition-issue --issue-key PROJ-123 --transition-id 31 --env .env
+jira-cli add-worklog --issue-key PROJ-123 --time-spent "2h 30m" --env .env
+jira-cli link-issues --inward-issue-key PROJ-100 --outward-issue-key PROJ-101 --link-type blocks --env .env
+jira-cli get-related-issues --issue-key PROJ-100 --env .env
+jira-cli get-development-info --issue-key PROJ-123 --env .env
+jira-cli get-issue-history --issue-key PROJ-123 --env .env
+jira-cli list-project-versions --project-key PROJ --env .env
+jira-cli list-statuses --project-key PROJ --env .env
+jira-cli download-attachment --issue-key PROJ-123 --env .env
+```
+
+Flags: `--env` (path to .env with credentials), `--output text|json`
 
 ## Workflows
 


### PR DESCRIPTION
## Summary
- Add `jira-cli` documentation to aio-jira SKILL.md, matching the CLI fallback pattern used by other MCP plugins (github, gitlab, confluence)
- Includes environment check, install command, and all 22 CLI commands with examples
- Bump aio-jira version to 2.2.0 and sync marketplace registry
- Update CLAUDE.md with current plugin categories and conventions

## Test plan
- [x] `bash scripts/validate-marketplace.sh` passes for aio-jira
- [x] Version synced between plugin.json and marketplace.json
- [x] CLI commands verified against `jira-cli --help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)