### PR TITLE
feat: add aio-html-artifacts plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -255,6 +255,15 @@
       "author": {
         "name": "aiocean"
       }
+    },
+    {
+      "name": "aio-html-artifacts",
+      "source": "./plugins/aio-html-artifacts",
+      "description": "Create self-contained HTML artifacts that keep humans in the loop: evidence-rich reports, narrative decks, side-by-side decision surfaces, and purpose-built editors with export loops. Uses a researched information grammar, layered detail, responsive design, accessibility, print support, and deterministic validation.",
+      "version": "1.0.0",
+      "author": {
+        "name": "aiocean"
+      }
     }
   ]
 }

--- a/.kanban/board.md
+++ b/.kanban/board.md
@@ -1,11 +1,12 @@
 # Kanban Board
-<!-- Updated: 2026-05-29 -->
+<!-- Updated: 2026-08-06 -->
 
 ## Doing
 
 ## Todo
 
 ## Done
+- [T-002](tasks/T-002-html-artifacts-plugin.md) Build the aio-html-artifacts plugin — high/L
 - [T-001](tasks/T-001-reorder-board-status.md) Sắp xếp lại thứ tự status trong board — medium/XS
 
 ## Backlog

--- a/.kanban/tasks/T-002-html-artifacts-plugin.md
+++ b/.kanban/tasks/T-002-html-artifacts-plugin.md
@@ -1,0 +1,27 @@
+# T-002 — Build the aio-html-artifacts plugin
+
+**Status:** Done
+**Priority:** high
+**Size:** L
+
+## Outcome
+
+Ship a marketplace-ready plugin that turns researched evidence into self-contained HTML reports, decks, comparison surfaces, and purpose-built editors with strong narrative structure, layered detail, accessibility, and export loops.
+
+## Definition of done
+
+- [x] Capture the Anthropic/Thariq source material and supporting information-design research.
+- [x] Add four focused skills with shared artifact grammar and genre-specific guidance.
+- [x] Include representative, self-contained example HTML files.
+- [x] Add deterministic validation for structure, accessibility basics, responsiveness, and interaction contracts.
+- [x] Register the plugin in the marketplace and document it in the root README.
+- [x] Validate metadata and render examples at desktop and mobile widths.
+
+## Verification
+
+- Marketplace: 29/29 plugins, 416/416 checks passing.
+- Skills: all four pass `quick_validate.py`; plugin passes `validate_plugin.py`.
+- Artifacts: all four pass `validate-html-artifact.mjs` with zero warnings.
+- Browser: desktop 1440×900 and mobile 390×844 render without page overflow or JavaScript errors.
+- Interaction: deck navigation, explorer scenario switching, editor constraints/diff/reset pass.
+- Print: report renders to 4 A4 pages; deck renders to 6 16:9 pages.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Plugin Marketplace
 
-A curated collection of 28 plugins for Claude Code — from codebase analysis to iOS debugging to ebook translation.
+A curated collection of 29 plugins for Claude Code — from codebase analysis to iOS debugging to rich HTML communication artifacts.
 
 ## Quick Start
 
@@ -28,6 +28,7 @@ Grouped plugins bundling multiple related skills into a single install.
 | **aio-saas-tools** | 1.0.5 | 4 | SaaS integrations — atlassian (Jira + Confluence), google-workspace, tanca (HR), x (Twitter).<br>`npx skills add aiocean/claude-plugins -s aio-saas-tools` |
 | **aio-research** | 1.0.5 | 2 | Research — research-kit (10-phase framework), rag-kit (Qdrant vector search).<br>`npx skills add aiocean/claude-plugins -s aio-research` |
 | **aio-diagramming** | 1.0.5 | 2 | Diagrams — mermaid (shareable URLs), grafana-diagram (dashboard diagrams from code).<br>`npx skills add aiocean/claude-plugins -s aio-diagramming` |
+| **aio-html-artifacts** | 1.0.0 | 4 | Rich agent-to-human communication in standalone HTML — evidence-led reports with code beside claims, narrative slide/side decks, aligned decision explorers, and purpose-built editors that export changes back to JSON/diff/prompt. Shared five-layer reading grammar, responsive/a11y/print requirements, four original examples, and deterministic validation.<br>`npx skills add aiocean/claude-plugins -s aio-html-artifacts` |
 
 ## Standalone Plugins
 

--- a/plugins/aio-html-artifacts/.claude-plugin/plugin.json
+++ b/plugins/aio-html-artifacts/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "aio-html-artifacts",
+  "description": "Create self-contained HTML artifacts that keep humans in the loop: evidence-rich reports, narrative decks, side-by-side decision surfaces, and purpose-built editors with export loops. Uses a researched information grammar, layered detail, responsive design, accessibility, print support, and deterministic validation.",
+  "version": "1.0.0",
+  "author": {
+    "name": "aiocean"
+  },
+  "repository": "https://github.com/aiocean/claude-plugins",
+  "license": "MIT"
+}

--- a/plugins/aio-html-artifacts/.codex-plugin/plugin.json
+++ b/plugins/aio-html-artifacts/.codex-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "aio-html-artifacts",
+  "version": "1.0.0",
+  "description": "Create self-contained HTML reports, decks, decision surfaces, and purpose-built editors with layered information, evidence proximity, accessibility, and export loops.",
+  "author": {
+    "name": "aiocean"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "AIO HTML Artifacts",
+    "shortDescription": "Rich HTML communication for reports, decks, decisions, and editors.",
+    "longDescription": "Build standalone HTML artifacts that keep humans in the loop through strong narrative structure, multiple levels of detail, evidence beside claims, responsive accessibility, print support, and deterministic exports.",
+    "developerName": "aiocean",
+    "category": "Productivity",
+    "capabilities": ["skills"],
+    "defaultPrompt": "Turn this work into the HTML artifact best suited to the human decision or task."
+  }
+}

--- a/plugins/aio-html-artifacts/README.md
+++ b/plugins/aio-html-artifacts/README.md
@@ -1,0 +1,41 @@
+# aio-html-artifacts
+
+Create HTML that functions as a richer communication surface between an agent and a human—not merely Markdown with CSS.
+
+## Skills
+
+| Skill | Human job | Typical outputs |
+|---|---|---|
+| `aio-html-report` | understand and audit | code review, incident, explainer, plan, status |
+| `aio-html-deck` | present and persuade | briefing, walkthrough, proposal, side deck |
+| `aio-html-explorer` | compare and decide | architecture options, design directions, scenario analysis |
+| `aio-html-editor` | manipulate and return intent | flag/config editor, triage, prompt tuner, annotation tool |
+
+All four use a shared five-layer reading ladder—glance, scan, understand, audit, act—plus evidence proximity, relationship-driven visual grammar, responsive/accessibility rules, and a deterministic validator. They deliberately do not share one page layout.
+
+## Optional live agent collaboration
+
+Standalone artifacts support reading, local interaction, and export without a server. For a live surface where a reader can select a confusing passage, comment on code/evidence, request an explanation, or chat with the active agent inside the HTML, install the companion plugin:
+
+```bash
+claude plugin install aio-message-bridge@aiocean-plugins
+```
+
+Then pair the relevant skill here with `aio-html-interactive`. This plugin supplies the content/narrative contract; the companion owns its browser scaffold, WebSocket relay, Monitor event loop, turn-taking, and cleanup. Nothing is vendored or duplicated. See [`references/live-collaboration.md`](references/live-collaboration.md).
+
+## Examples
+
+Open [`examples/index.html`](examples/index.html) locally. Each example is a standalone file with no build step or external dependency.
+
+## Validation
+
+```bash
+node scripts/validate-html-artifact.mjs --kind report examples/engineering-investigation-report.html
+node scripts/validate-html-artifact.mjs --kind deck examples/migration-briefing-deck.html
+node scripts/validate-html-artifact.mjs --kind explorer examples/queue-architecture-explorer.html
+node scripts/validate-html-artifact.mjs --kind editor examples/rollout-editor.html
+```
+
+## Research basis
+
+The plugin is an original synthesis inspired by Thariq Shihipar's Anthropic article [“Using Claude Code: The unreasonable effectiveness of HTML”](https://claude.com/blog/using-claude-code-the-unreasonable-effectiveness-of-html) and its [official example gallery](https://thariqs.github.io/html-effectiveness/), with supporting principles from Shneiderman's information-seeking mantra, Segel and Heer's narrative visualization research, and WCAG 2.2. See [`references/research-foundations.md`](references/research-foundations.md).

--- a/plugins/aio-html-artifacts/examples/engineering-investigation-report.html
+++ b/plugins/aio-html-artifacts/examples/engineering-investigation-report.html
@@ -1,0 +1,220 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Example evidence-led engineering investigation report with inline code and causal flow.">
+  <title>Webhook recovery path — engineering investigation</title>
+  <style>
+    :root { --paper:#f4f0e8; --ink:#17211d; --muted:#65706a; --rule:#c8c4ba; --red:#b6422f; --amber:#c57b1c; --green:#27755a; --code:#101713; --code-ink:#d9e7df; --mark:#ffe08a; }
+    * { box-sizing:border-box; }
+    html { scroll-behavior:smooth; }
+    body { margin:0; background:var(--paper); color:var(--ink); font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif; line-height:1.55; }
+    a { color:inherit; }
+    a:focus-visible, summary:focus-visible { outline:3px solid var(--amber); outline-offset:4px; }
+    .masthead { border-bottom:1px solid var(--ink); padding:18px max(24px,calc((100vw - 1180px)/2)); display:flex; justify-content:space-between; gap:20px; font-size:.78rem; letter-spacing:.08em; text-transform:uppercase; }
+    .status { display:inline-flex; align-items:center; gap:8px; font-weight:800; color:var(--red); }
+    .status::before { content:""; width:9px; height:9px; border-radius:50%; background:currentColor; }
+    .hero { max-width:1180px; margin:auto; display:grid; grid-template-columns:1fr 280px; gap:72px; padding:74px 24px 58px; border-bottom:1px solid var(--rule); }
+    .kicker { color:var(--red); font-size:.76rem; letter-spacing:.16em; text-transform:uppercase; font-weight:850; }
+    h1 { font-family:Georgia,serif; font-size:clamp(2.8rem,7vw,6.6rem); line-height:.91; letter-spacing:-.055em; max-width:900px; margin:15px 0 28px; }
+    .dek { font-family:Georgia,serif; font-size:clamp(1.2rem,2vw,1.55rem); max-width:760px; margin:0; }
+    .verdict { border-top:5px solid var(--red); padding-top:18px; align-self:end; }
+    .verdict strong { display:block; font-size:1.75rem; line-height:1.05; margin-bottom:12px; }
+    .verdict p { margin:0; color:var(--muted); font-size:.92rem; }
+    .body { max-width:1180px; margin:auto; padding:0 24px 100px; display:grid; grid-template-columns:210px minmax(0,1fr); gap:72px; }
+    nav { position:sticky; top:20px; align-self:start; padding-top:54px; font-size:.8rem; }
+    nav b { display:block; margin-bottom:14px; text-transform:uppercase; letter-spacing:.14em; }
+    nav a { display:block; padding:8px 0; color:var(--muted); text-decoration:none; border-bottom:1px solid var(--rule); }
+    nav a:hover { color:var(--ink); }
+    article { min-width:0; }
+    section { padding:58px 0; border-bottom:1px solid var(--rule); }
+    h2 { font-family:Georgia,serif; font-size:clamp(2rem,4vw,3.8rem); letter-spacing:-.04em; line-height:1; margin:0 0 28px; max-width:780px; }
+    h3 { font-size:1rem; margin:0 0 9px; }
+    .lead { font-size:1.12rem; max-width:740px; }
+    .fact-strip { display:grid; grid-template-columns:repeat(3,1fr); border-block:1px solid var(--ink); margin:34px 0 10px; }
+    .fact { padding:22px 22px 22px 0; }
+    .fact + .fact { padding-left:22px; border-left:1px solid var(--rule); }
+    .fact span { display:block; color:var(--muted); font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; }
+    .fact strong { display:block; margin-top:6px; font:700 1.25rem Georgia,serif; }
+    .flow { display:grid; grid-template-columns:1fr 42px 1fr 42px 1fr; align-items:stretch; margin:38px 0; }
+    .node { border:1px solid var(--ink); padding:22px; background:rgba(255,255,255,.28); }
+    .node small { display:block; color:var(--muted); margin-top:8px; }
+    .arrow { display:grid; place-items:center; font-size:1.6rem; }
+    .node.break { border-color:var(--red); box-shadow:inset 0 -5px var(--red); }
+    .finding { display:grid; grid-template-columns:86px 1fr; gap:24px; margin:40px 0 24px; }
+    .finding .index { font:700 2.8rem Georgia,serif; color:var(--red); border-top:1px solid var(--red); padding-top:4px; }
+    .finding p { margin:.25rem 0 0; max-width:720px; }
+    .evidence { display:grid; grid-template-columns:minmax(0,1fr) 230px; background:var(--code); color:var(--code-ink); border-radius:3px; overflow:hidden; margin:24px 0 36px; }
+    .code { overflow:auto; padding:20px 0; font:13px/1.7 ui-monospace,SFMono-Regular,Consolas,monospace; }
+    .source { display:block; padding:0 20px 12px; color:#90a39a; font-size:11px; letter-spacing:.04em; }
+    .line { display:block; padding:0 20px; white-space:pre; border-left:4px solid transparent; }
+    .line::before { content:attr(data-line); display:inline-block; width:32px; color:#60736a; user-select:none; }
+    .line.hot { background:#2b2116; border-left-color:var(--mark); color:#fff2c7; }
+    .annotation { border-left:1px solid #3c4b43; padding:48px 20px 20px; color:#bdc9c3; font-size:.84rem; }
+    .annotation b { color:var(--mark); display:block; margin-bottom:8px; }
+    .causal { counter-reset:step; margin:35px 0 0; }
+    .cause { display:grid; grid-template-columns:55px 1fr; gap:20px; padding:22px 0; border-top:1px solid var(--rule); }
+    .cause::before { counter-increment:step; content:counter(step); width:36px; height:36px; border-radius:50%; display:grid; place-items:center; color:white; background:var(--ink); font-weight:800; }
+    .cause strong { display:block; margin-bottom:5px; }
+    .cause p { margin:0; color:var(--muted); }
+    .actions { width:100%; border-collapse:collapse; margin-top:28px; }
+    .actions th, .actions td { text-align:left; vertical-align:top; padding:15px 10px; border-bottom:1px solid var(--rule); }
+    .actions th { font-size:.72rem; text-transform:uppercase; letter-spacing:.1em; }
+    .priority { font-weight:800; color:var(--red); }
+    details { margin-top:28px; border-block:1px solid var(--rule); padding:18px 0; }
+    summary { cursor:pointer; font-weight:800; }
+    .legend { color:var(--muted); font-size:.85rem; }
+    .tag { display:inline-block; border:1px solid currentColor; padding:2px 7px; margin-right:5px; font-size:.7rem; text-transform:uppercase; letter-spacing:.06em; }
+    .observed { color:var(--green); } .inferred { color:var(--amber); }
+    @media (max-width:850px) {
+      .hero { grid-template-columns:1fr; gap:36px; padding-top:48px; }
+      .verdict { max-width:520px; }
+      .body { grid-template-columns:1fr; gap:0; }
+      nav { position:static; display:flex; overflow:auto; gap:18px; padding:20px 0; border-bottom:1px solid var(--rule); }
+      nav b { display:none; } nav a { white-space:nowrap; border:0; }
+      .evidence { grid-template-columns:1fr; }
+      .annotation { border-left:0; border-top:1px solid #3c4b43; padding:18px 20px; }
+    }
+    @media (max-width:580px) {
+      .masthead { align-items:flex-start; flex-direction:column; }
+      .hero, .body { padding-left:18px; padding-right:18px; }
+      .fact-strip { grid-template-columns:1fr; }
+      .fact + .fact { border-left:0; border-top:1px solid var(--rule); padding-left:0; }
+      .flow { grid-template-columns:1fr; gap:8px; }
+      .arrow { transform:rotate(90deg); }
+      .finding { grid-template-columns:56px 1fr; gap:12px; }
+      .actions, .actions tbody, .actions tr, .actions td { display:block; }
+      .actions thead { position:absolute; clip:rect(0 0 0 0); }
+      .actions tr { padding:14px 0; border-bottom:1px solid var(--rule); }
+      .actions td { border:0; padding:3px 0; }
+      .actions td::before { content:attr(data-label) ": "; font-weight:800; }
+    }
+    @media (prefers-reduced-motion:reduce) { html { scroll-behavior:auto; } }
+    @media print {
+      :root { --paper:#fff; }
+      nav { display:none; } .body { display:block; } .hero { padding-top:28px; }
+      section { break-inside:auto; } .evidence, .finding, .cause, tr { break-inside:avoid; }
+      details > * { display:block; } summary { display:none; }
+    }
+  </style>
+</head>
+<body>
+  <header class="masthead">
+    <span>Atlas Engineering · Investigation 017</span>
+    <span class="status">Action required before rollout</span>
+  </header>
+
+  <main>
+    <div class="hero">
+      <div>
+        <div class="kicker">Webhook authorization · 06 Aug 2026</div>
+        <h1>The recovery path stops one service too early.</h1>
+        <p class="dek">The new authorization scope is persisted correctly, but shops that abandon OAuth can remain without the dispute webhook because recovery validates only the legacy installer.</p>
+      </div>
+      <aside class="verdict" aria-label="Verdict">
+        <strong>Do not approve as complete.</strong>
+        <p>High confidence · one blocking gap · evidence from two handlers and the queue topology.</p>
+      </aside>
+    </div>
+
+    <div class="body">
+      <nav aria-label="Report sections">
+        <b>Read the case</b>
+        <a href="#answer">01 · Answer</a>
+        <a href="#path">02 · System path</a>
+        <a href="#evidence">03 · Code evidence</a>
+        <a href="#cause">04 · Causal chain</a>
+        <a href="#actions">05 · Actions</a>
+      </nav>
+
+      <article>
+        <section id="answer">
+          <h2>The banner recovers scope consent, not webhook delivery.</h2>
+          <p class="lead"><span class="tag observed">Observed</span> A shop remains eligible for the banner while <code>shops.scopes</code> lacks the new scope. That part is correct. A separate recovery route is needed after the scope arrives: the current validation command reaches only the order webhook installer.</p>
+          <div class="fact-strip" aria-label="Investigation summary">
+            <div class="fact"><span>Scope fallback</span><strong>Works as intended</strong></div>
+            <div class="fact"><span>Webhook recovery</span><strong>Incomplete</strong></div>
+            <div class="fact"><span>Release impact</span><strong>Silent missed events</strong></div>
+          </div>
+          <p class="legend"><span class="tag observed">Observed</span> directly supported by source &nbsp; <span class="tag inferred">Inferred</span> consequence derived from the observed path</p>
+        </section>
+
+        <section id="path">
+          <h2>The successful path crosses three boundaries.</h2>
+          <p class="lead">The banner and OAuth callback only establish permission. Delivery becomes reliable when the callback also reaches the installer that owns dispute subscriptions.</p>
+          <div class="flow" role="img" aria-label="Shop clicks banner, OAuth callback stores scope, then webhook recovery should register dispute topics">
+            <div class="node"><b>1 · Consent</b><small>Banner opens OAuth only for flagged shops missing the scope.</small></div>
+            <div class="arrow" aria-hidden="true">→</div>
+            <div class="node"><b>2 · Persist</b><small>Callback stores the granted scope in <code>shops.scopes</code>.</small></div>
+            <div class="arrow" aria-hidden="true">→</div>
+            <div class="node break"><b>3 · Recover</b><small>Validation invokes the legacy order installer, not the dispute owner.</small></div>
+          </div>
+        </section>
+
+        <section id="evidence" data-evidence>
+          <h2>The decisive branch is visible in six lines.</h2>
+          <div class="finding">
+            <div class="index">01</div>
+            <div><h3>Banner eligibility survives an abandoned OAuth flow</h3><p>The predicate reads persisted scopes. If the callback never saves the new value, the predicate remains true and the user sees the banner again.</p></div>
+          </div>
+          <div class="evidence">
+            <div class="code" aria-label="Code excerpt from banner eligibility">
+              <span class="source">web/app/disputes/banner.ts · lines 41–46 · fictional example</span>
+              <span class="line" data-line="41">const granted = new Set(shop.scopes.split(","));</span>
+              <span class="line hot" data-line="42">const missing = !granted.has(DISPUTE_SCOPE);</span>
+              <span class="line" data-line="43"></span>
+              <span class="line" data-line="44">return shop.flags.disputes &amp;&amp; missing;</span>
+            </div>
+            <aside class="annotation"><b>Why this answers the question</b>The database remains authoritative. Abandoning OAuth produces no persisted scope, so <code>missing</code> stays true.</aside>
+          </div>
+
+          <div class="finding">
+            <div class="index">02</div>
+            <div><h3>Recovery invokes only the order installer</h3><p>The callback publishes a validation command, but the consumer hard-codes one Lambda target. No SNS fan-out or second SQS consumer appears in the inspected topology.</p></div>
+          </div>
+          <div class="evidence">
+            <div class="code" aria-label="Code excerpt from webhook validation consumer">
+              <span class="source">workers/validate-webhooks.ts · lines 72–80 · fictional example</span>
+              <span class="line" data-line="72">if (shop.active &amp;&amp; shop.scopes.includes(requiredScope)) {</span>
+              <span class="line hot" data-line="73">  await lambda.invoke({</span>
+              <span class="line hot" data-line="74">    FunctionName: "orders-install-webhooks-prod",</span>
+              <span class="line" data-line="75">    Payload: JSON.stringify({ shopId: shop.id }),</span>
+              <span class="line" data-line="76">  });</span>
+              <span class="line" data-line="77">}</span>
+            </div>
+            <aside class="annotation"><b>The gap</b>The condition is right, but the only named target owns order topics. Permission recovery does not imply dispute subscription recovery.</aside>
+          </div>
+        </section>
+
+        <section id="cause">
+          <h2>This fails silently, not immediately.</h2>
+          <div class="causal">
+            <div class="cause"><div><strong>User completes the second OAuth attempt.</strong><p>The scope is saved, so the banner correctly disappears.</p></div></div>
+            <div class="cause"><div><strong>The validation message is consumed successfully.</strong><p>Queue health remains green because the consumer and Lambda invocation both succeed.</p></div></div>
+            <div class="cause"><div><strong>The wrong installer owns the recovery action.</strong><p>The dispute topic is never registered; there is no failing call to alarm on.</p></div></div>
+            <div class="cause"><div><strong>Missing events surface later as data drift.</strong><p><span class="tag inferred">Inferred</span> The first visible symptom is stale dispute state, not an authorization error.</p></div></div>
+          </div>
+        </section>
+
+        <section id="actions">
+          <h2>Close the loop at the owner boundary.</h2>
+          <p class="lead">Make one component authoritative for dispute webhook reconciliation and invoke it idempotently after scope persistence. Then observe the subscription result, not merely the queue delivery.</p>
+          <table class="actions">
+            <thead><tr><th>Priority</th><th>Action</th><th>Proof of completion</th></tr></thead>
+            <tbody>
+              <tr><td data-label="Priority" class="priority">Blocker</td><td data-label="Action">Route validation to the dispute webhook reconciler.</td><td data-label="Proof">A shop with scope but no topic receives an idempotent registration call.</td></tr>
+              <tr><td data-label="Priority">Before ramp</td><td data-label="Action">Emit desired vs actual topic counts.</td><td data-label="Proof">Alert fires when reconciliation leaves a required topic absent.</td></tr>
+              <tr><td data-label="Priority">Verification</td><td data-label="Action">Test abandon → retry → callback → reconcile.</td><td data-label="Proof">Banner disappears only after scope save; webhook exists after recovery.</td></tr>
+            </tbody>
+          </table>
+          <details>
+            <summary>Evidence register and limits</summary>
+            <p>This is a fictional capability example. A real report must include repository, MR/SHA, file lines, AWS resource ARNs or names, inspection time, and any unavailable evidence. The conclusion would change if an uninspected SNS subscription or independent scheduled reconciler owns dispute registration.</p>
+          </details>
+        </section>
+      </article>
+    </div>
+  </main>
+</body>
+</html>

--- a/plugins/aio-html-artifacts/examples/index.html
+++ b/plugins/aio-html-artifacts/examples/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Gallery of four distinct HTML communication genres from aio-html-artifacts.">
+  <title>aio-html-artifacts — example gallery</title>
+  <style>
+    :root { --paper:#f7f4eb; --ink:#19201d; --muted:#65706b; --rule:#bfc5bf; --blue:#275dcc; }
+    * { box-sizing:border-box; }
+    body { margin:0; background:var(--paper); color:var(--ink); font-family:ui-sans-serif,system-ui,sans-serif; }
+    header, main { max-width:1120px; margin:auto; padding-inline:22px; }
+    header { padding-top:70px; padding-bottom:48px; border-bottom:2px solid var(--ink); }
+    h1 { font-size:clamp(3rem,8vw,7rem); line-height:.9; letter-spacing:-.065em; margin:0 0 28px; }
+    header p { max-width:720px; color:var(--muted); font-size:1.15rem; line-height:1.55; }
+    main { padding-top:40px; padding-bottom:80px; }
+    article { display:grid; grid-template-columns:80px 1fr 180px; gap:22px; padding:30px 0; border-bottom:1px solid var(--rule); align-items:start; }
+    .n { font-size:2.8rem; font-weight:900; color:var(--rule); }
+    h2 { margin:2px 0 8px; font-size:1.8rem; }
+    p { margin:0; color:var(--muted); line-height:1.5; }
+    a { display:inline-flex; justify-content:center; align-items:center; min-height:44px; border:1px solid var(--ink); color:var(--ink); text-decoration:none; font-weight:800; }
+    a:hover { background:var(--ink); color:var(--paper); }
+    a:focus-visible { outline:3px solid var(--blue); outline-offset:3px; }
+    footer { max-width:1120px; margin:auto; padding:0 22px 50px; color:var(--muted); font-size:.8rem; }
+    @media (max-width:680px) { article { grid-template-columns:50px 1fr; } article a { grid-column:2; width:max-content; padding:0 18px; } }
+    @media print { a::after { content:" · " attr(href); } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>One medium.<br>Four human jobs.</h1>
+    <p>These examples share an information grammar, not a visual template. Open them to compare an auditable report, a paced deck, an aligned decision surface, and a stateful editor with an export loop.</p>
+  </header>
+  <main>
+    <article><span class="n">01</span><div><h2>Evidence-led report</h2><p>Verdict first, causal system path, actual code beside each claim, and concrete actions.</p></div><a href="engineering-investigation-report.html">Open report →</a></article>
+    <article><span class="n">02</span><div><h2>Narrative deck</h2><p>One claim per scene, keyboard navigation, mobile reading flow, and print-to-PDF behavior.</p></div><a href="migration-briefing-deck.html">Open deck →</a></article>
+    <article><span class="n">03</span><div><h2>Decision explorer</h2><p>Alternatives on a shared baseline, scenario sensitivity, evidence limits, and falsifiable recommendation.</p></div><a href="queue-architecture-explorer.html">Open explorer →</a></article>
+    <article><span class="n">04</span><div><h2>Purpose-built editor</h2><p>Domain constraints, live journey preview, dirty state, reset, and deterministic changed-key export.</p></div><a href="rollout-editor.html">Open editor →</a></article>
+  </main>
+  <footer>All scenarios and data are fictional. Examples are original work created for the aio-html-artifacts plugin.</footer>
+</body>
+</html>

--- a/plugins/aio-html-artifacts/examples/migration-briefing-deck.html
+++ b/plugins/aio-html-artifacts/examples/migration-briefing-deck.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Example narrative HTML deck for an infrastructure migration decision.">
+  <title>One queue, two clocks — migration briefing</title>
+  <style>
+    :root { --night:#10121a; --paper:#f3f0e6; --lime:#d7ff62; --coral:#ff7557; --sky:#76c8ff; --muted:#a7a9b4; }
+    * { box-sizing:border-box; }
+    html, body { margin:0; min-height:100%; background:var(--night); color:var(--paper); font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif; }
+    body { overflow:hidden; }
+    main { min-height:100vh; }
+    .slide { display:none; min-height:100vh; padding:clamp(28px,6vw,88px); position:relative; overflow:hidden; align-content:center; }
+    .slide.active { display:grid; animation:arrive .35s ease-out; }
+    .eyebrow { font-size:.76rem; letter-spacing:.18em; text-transform:uppercase; color:var(--lime); font-weight:800; }
+    h1, h2 { margin:.16em 0; letter-spacing:-.055em; line-height:.93; max-width:1100px; }
+    h1 { font-size:clamp(4rem,10vw,10rem); }
+    h2 { font-size:clamp(3rem,8vw,7rem); }
+    p { font-size:clamp(1.05rem,2vw,1.5rem); line-height:1.45; max-width:760px; color:#d3d4da; }
+    .accent { color:var(--lime); }
+    .coral { color:var(--coral); }
+    .quiet { color:var(--muted); }
+    .split { display:grid; grid-template-columns:1fr 1fr; gap:clamp(28px,7vw,100px); align-items:center; width:min(1180px,100%); margin:auto; }
+    .big-number { font-size:clamp(7rem,20vw,18rem); line-height:.78; font-weight:900; letter-spacing:-.09em; color:var(--coral); }
+    .clock { width:min(420px,72vw); aspect-ratio:1; border:2px solid var(--paper); border-radius:50%; position:relative; margin:auto; }
+    .clock::before, .clock::after { content:""; position:absolute; left:50%; top:50%; height:33%; width:5px; background:var(--lime); transform-origin:50% 0; }
+    .clock::before { transform:rotate(145deg); } .clock::after { height:22%; background:var(--coral); transform:rotate(248deg); }
+    .clock span { position:absolute; inset:19%; border:1px dashed #5a5d68; border-radius:50%; display:grid; place-items:center; text-align:center; font-weight:800; }
+    .lanes { width:min(1160px,100%); margin:40px auto 0; display:grid; gap:22px; }
+    .lane { display:grid; grid-template-columns:180px 1fr; gap:28px; align-items:center; }
+    .lane b { font-size:1.1rem; }
+    .track { height:54px; border:1px solid #555965; position:relative; background:#171a24; }
+    .track span { position:absolute; inset:8px auto 8px 8px; display:flex; align-items:center; padding:0 16px; color:var(--night); font-weight:900; }
+    .legacy { width:82%; background:var(--coral); } .target { width:34%; background:var(--lime); }
+    .track em { position:absolute; right:12px; top:15px; font-style:normal; font-size:.78rem; color:var(--muted); }
+    .sequence { display:grid; grid-template-columns:repeat(4,1fr); width:min(1180px,100%); margin:50px auto 0; border-top:1px solid #646772; }
+    .step { position:relative; padding:34px 26px 0 0; }
+    .step::before { content:attr(data-n); position:absolute; top:-17px; left:0; width:34px; height:34px; background:var(--night); border:1px solid var(--lime); color:var(--lime); border-radius:50%; display:grid; place-items:center; font-weight:800; }
+    .step strong { display:block; font-size:1.25rem; margin-bottom:8px; }
+    .step small { color:var(--muted); line-height:1.5; }
+    .decision { background:var(--lime); color:var(--night); }
+    .decision .eyebrow, .decision p { color:#384016; }
+    .decision h2 { max-width:1000px; }
+    .ask { margin-top:42px; border-top:2px solid var(--night); padding-top:18px; display:flex; gap:40px; align-items:baseline; max-width:980px; }
+    .ask b { font-size:clamp(1.3rem,2.7vw,2.4rem); }
+    .evidence-note { position:absolute; bottom:36px; left:clamp(28px,6vw,88px); color:var(--muted); font-size:.75rem; }
+    .controls { position:fixed; z-index:10; right:22px; bottom:20px; display:flex; align-items:center; gap:8px; background:#20232e; border:1px solid #484b56; border-radius:999px; padding:7px; }
+    button { min-width:44px; min-height:44px; border:0; border-radius:50%; background:transparent; color:var(--paper); font-size:1rem; cursor:pointer; }
+    button:hover { background:#343744; }
+    button:focus-visible { outline:3px solid var(--lime); outline-offset:3px; }
+    #count { min-width:58px; text-align:center; font:700 .8rem ui-monospace,monospace; }
+    .progress { position:fixed; z-index:12; left:0; bottom:0; height:4px; width:100%; background:#2a2d36; }
+    .progress span { display:block; height:100%; width:16.67%; background:var(--lime); transition:width .25s ease; }
+    .notes { display:none; }
+    .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
+    @keyframes arrive { from { opacity:0; transform:translateY(12px); } to { opacity:1; transform:none; } }
+    @media (max-width:720px) {
+      body { overflow:auto; }
+      .slide, .slide.active { display:grid; min-height:auto; padding:72px 22px; border-bottom:1px solid #383b46; animation:none; }
+      .slide:first-child { min-height:92vh; }
+      .split { grid-template-columns:1fr; }
+      .clock { width:min(270px,72vw); }
+      .lane { grid-template-columns:1fr; gap:8px; }
+      .sequence { grid-template-columns:1fr; border-top:0; border-left:1px solid #646772; margin-left:16px; }
+      .step { padding:0 0 34px 34px; }
+      .step::before { top:0; left:-17px; }
+      .controls, .progress { display:none; }
+      .evidence-note { position:static; margin-top:44px; }
+      .ask { display:block; }
+    }
+    @media (prefers-reduced-motion:reduce) { .slide.active { animation:none; } .progress span { transition:none; } }
+    @media print {
+      @page { size:landscape; margin:0; }
+      body { background:#fff; color:#111; overflow:visible; }
+      .slide, .slide.active { display:grid; height:100vh; min-height:100vh; break-after:page; color:inherit; background:#fff; animation:none; }
+      .decision { background:#e8f7b6; }
+      .controls, .progress { display:none; }
+      .quiet, .evidence-note, p { color:#444; }
+      .notes { display:block; position:absolute; bottom:20px; right:24px; font-size:10px; color:#555; }
+    }
+  </style>
+</head>
+<body>
+  <header class="sr-only">Migration decision briefing</header>
+  <main aria-label="Migration briefing deck">
+    <section class="slide active" id="slide-1" aria-label="Slide 1 of 6">
+      <div>
+        <span class="eyebrow">Decision briefing · 8 minutes</span>
+        <h1>One queue.<br><span class="accent">Two clocks.</span></h1>
+        <p>Why the migration should optimize for recovery time—not raw throughput.</p>
+      </div>
+      <small class="evidence-note">Fictional example · source snapshot: load test LT-204</small>
+    </section>
+
+    <section class="slide" id="slide-2" aria-label="Slide 2 of 6">
+      <div class="split">
+        <div>
+          <span class="eyebrow">Reality</span>
+          <h2>Peak load is <span class="coral">not</span> the problem.</h2>
+          <p>At 2.4× expected traffic, both designs stay below 55% consumer utilization.</p>
+        </div>
+        <div class="big-number" aria-label="55 percent">55<span style="font-size:.35em">%</span></div>
+      </div>
+      <small class="evidence-note">Evidence: 30-minute steady-state load test; identical payload and concurrency.</small>
+    </section>
+
+    <section class="slide" id="slide-3" aria-label="Slide 3 of 6">
+      <div class="split">
+        <div class="clock" role="img" aria-label="Two recovery clocks, broker redelivery and application retry"><span>broker<br>vs<br>application</span></div>
+        <div>
+          <span class="eyebrow">Tension</span>
+          <h2>A failure starts <span class="accent">two timers.</span></h2>
+          <p>The legacy path waits for visibility timeout before it can retry. The target path records intent immediately and schedules recovery independently.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="slide" id="slide-4" aria-label="Slide 4 of 6" data-evidence>
+      <div>
+        <span class="eyebrow">Evidence · p95 recovery</span>
+        <h2>Seven minutes become <span class="accent">ninety seconds.</span></h2>
+        <div class="lanes" role="img" aria-label="Legacy recovery takes 7 minutes 4 seconds; target recovery takes 1 minute 31 seconds">
+          <div class="lane"><b>Legacy</b><div class="track"><span class="legacy">7m 04s</span><em>visibility timeout</em></div></div>
+          <div class="lane"><b>Target</b><div class="track"><span class="target">1m 31s</span><em>durable retry intent</em></div></div>
+        </div>
+      </div>
+      <small class="evidence-note">Evidence: 120 injected worker failures; p95 end-to-end recovery. Baseline starts at zero.</small>
+    </section>
+
+    <section class="slide" id="slide-5" aria-label="Slide 5 of 6">
+      <div>
+        <span class="eyebrow">Resolution · reversible sequence</span>
+        <h2>Migrate the <span class="accent">clock</span> before the traffic.</h2>
+        <div class="sequence">
+          <div class="step" data-n="1"><strong>Shadow intent</strong><small>Write retry intent while legacy remains authoritative.</small></div>
+          <div class="step" data-n="2"><strong>Compare recovery</strong><small>Measure missing, duplicate, and late outcomes for one week.</small></div>
+          <div class="step" data-n="3"><strong>Shift 10%</strong><small>Move one reversible cohort with automatic rollback.</small></div>
+          <div class="step" data-n="4"><strong>Retire timeout</strong><small>Remove the old clock only after parity evidence.</small></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="slide decision" id="slide-6" aria-label="Slide 6 of 6">
+      <div>
+        <span class="eyebrow">The ask</span>
+        <h2>Approve a one-week shadow, <em>not</em> a full migration.</h2>
+        <p>We accept temporary dual-write complexity to buy observable recovery evidence before the one-way cutover.</p>
+        <div class="ask"><span>Decision today</span><b>Authorize shadow traffic and the rollback SLO.</b></div>
+      </div>
+      <aside class="notes">Speaker note: confirm the rollback owner and 2-minute recovery SLO before closing.</aside>
+    </section>
+  </main>
+
+  <div class="controls" aria-label="Slide controls">
+    <button id="prev" type="button" aria-label="Previous slide">←</button>
+    <span id="count" aria-live="polite">1 / 6</span>
+    <button id="next" type="button" aria-label="Next slide">→</button>
+  </div>
+  <div class="progress" aria-hidden="true"><span id="bar"></span></div>
+
+  <script>
+    const slides = [...document.querySelectorAll('.slide')];
+    let current = Math.max(0, slides.findIndex(s => '#' + s.id === location.hash));
+    if (current < 0) current = 0;
+    function show(index) {
+      current = Math.max(0, Math.min(slides.length - 1, index));
+      slides.forEach((slide, i) => slide.classList.toggle('active', i === current));
+      document.getElementById('count').textContent = `${current + 1} / ${slides.length}`;
+      document.getElementById('bar').style.width = `${((current + 1) / slides.length) * 100}%`;
+      history.replaceState(null, '', `#${slides[current].id}`);
+    }
+    document.getElementById('prev').addEventListener('click', () => show(current - 1));
+    document.getElementById('next').addEventListener('click', () => show(current + 1));
+    document.addEventListener('keydown', event => {
+      if (['ArrowRight', 'PageDown', ' '].includes(event.key)) { event.preventDefault(); show(current + 1); }
+      if (['ArrowLeft', 'PageUp'].includes(event.key)) { event.preventDefault(); show(current - 1); }
+      if (event.key === 'Home') show(0);
+      if (event.key === 'End') show(slides.length - 1);
+    });
+    show(current);
+  </script>
+</body>
+</html>

--- a/plugins/aio-html-artifacts/examples/queue-architecture-explorer.html
+++ b/plugins/aio-html-artifacts/examples/queue-architecture-explorer.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Example HTML decision explorer comparing three queue architectures on aligned criteria.">
+  <title>Queue architecture explorer — three honest tradeoffs</title>
+  <style>
+    :root { --canvas:#eef2ef; --ink:#13231d; --muted:#61716a; --line:#aebbb5; --blue:#2e66d2; --violet:#7049b9; --orange:#d36932; --white:#fbfcf8; --soft:#dde5df; }
+    * { box-sizing:border-box; }
+    html { scroll-behavior:smooth; }
+    body { margin:0; background:var(--canvas); color:var(--ink); font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif; line-height:1.45; }
+    button:focus-visible, a:focus-visible { outline:3px solid var(--blue); outline-offset:3px; }
+    header { padding:24px max(22px,calc((100vw - 1240px)/2)); border-bottom:1px solid var(--line); display:flex; justify-content:space-between; gap:20px; font-size:.76rem; text-transform:uppercase; letter-spacing:.12em; }
+    main { max-width:1240px; margin:auto; padding:56px 22px 100px; }
+    .intro { display:grid; grid-template-columns:minmax(0,1fr) 350px; gap:64px; align-items:end; padding-bottom:48px; }
+    h1 { font-size:clamp(3rem,7vw,6.2rem); line-height:.91; letter-spacing:-.06em; margin:0; max-width:850px; }
+    .question { border-left:5px solid var(--blue); padding-left:20px; font-size:1.05rem; }
+    .question b { display:block; font-size:.72rem; text-transform:uppercase; letter-spacing:.13em; margin-bottom:8px; color:var(--blue); }
+    .frame { display:grid; grid-template-columns:190px repeat(3,1fr); border-top:2px solid var(--ink); border-bottom:1px solid var(--ink); }
+    .cell { padding:22px 18px; border-bottom:1px solid var(--line); min-width:0; }
+    .cell:not(:nth-child(4n+1)) { border-left:1px solid var(--line); }
+    .label { color:var(--muted); text-transform:uppercase; letter-spacing:.1em; font-size:.7rem; font-weight:800; }
+    .option-head { min-height:170px; position:relative; padding-top:35px; }
+    .option-head::before { content:attr(data-letter); position:absolute; top:12px; right:14px; font-size:5rem; line-height:1; font-weight:900; opacity:.1; }
+    .option-head h2 { font-size:1.55rem; line-height:1.05; margin:0 0 12px; }
+    .option-head p { color:var(--muted); font-size:.9rem; margin:0; }
+    .a { color:var(--blue); } .b { color:var(--violet); } .c { color:var(--orange); }
+    .constraint { font-weight:750; }
+    .pass::before { content:"✓ "; color:#19724e; } .risk::before { content:"△ "; color:#9d5d13; } .fail::before { content:"× "; color:#a5302f; }
+    .metric { display:flex; align-items:baseline; gap:7px; }
+    .metric strong { font-size:1.65rem; }
+    .meter { height:7px; background:#d5ddd8; margin-top:11px; position:relative; }
+    .meter span { display:block; height:100%; background:currentColor; width:var(--value); }
+    .evidence { color:var(--muted); font-size:.78rem; margin-top:10px; }
+    .scenario { margin:58px 0 26px; display:flex; justify-content:space-between; gap:24px; align-items:end; }
+    .scenario h2 { margin:0; font-size:clamp(1.8rem,4vw,3.2rem); letter-spacing:-.04em; }
+    .switch { display:flex; border:1px solid var(--ink); padding:3px; border-radius:999px; }
+    .switch button { border:0; background:transparent; color:var(--ink); min-height:42px; padding:0 18px; border-radius:999px; cursor:pointer; font-weight:800; }
+    .switch button[aria-pressed="true"] { background:var(--ink); color:var(--white); }
+    .frontier { position:relative; min-height:360px; border:1px solid var(--ink); background:linear-gradient(to right,transparent 49.8%,rgba(19,35,29,.1) 50%,transparent 50.2%),linear-gradient(to bottom,transparent 49.8%,rgba(19,35,29,.1) 50%,transparent 50.2%); }
+    .axis-x, .axis-y { position:absolute; color:var(--muted); font-size:.72rem; text-transform:uppercase; letter-spacing:.1em; }
+    .axis-x { right:18px; bottom:12px; } .axis-y { left:14px; top:12px; }
+    .dot { position:absolute; left:var(--x); bottom:var(--y); transform:translate(-50%,50%); width:86px; height:86px; border-radius:50%; color:white; display:grid; place-items:center; text-align:center; font-weight:850; box-shadow:0 7px 0 rgba(19,35,29,.18); transition:left .25s,bottom .25s; }
+    .dot small { display:block; font-weight:500; font-size:.68rem; }
+    .dot-a { background:var(--blue); } .dot-b { background:var(--violet); } .dot-c { background:var(--orange); }
+    .recommendation { margin-top:58px; background:var(--ink); color:var(--white); display:grid; grid-template-columns:210px 1fr; gap:36px; padding:38px; }
+    .recommendation .label { color:#aebbb5; }
+    .recommendation h2 { margin:0 0 13px; font-size:clamp(2rem,4vw,3.6rem); line-height:1; letter-spacing:-.04em; }
+    .recommendation p { margin:0; max-width:780px; color:#ccd5d0; font-size:1.05rem; }
+    .falsifier { margin-top:18px; color:#fff; padding-top:18px; border-top:1px solid #506159; }
+    details { margin-top:36px; padding:20px 0; border-block:1px solid var(--line); }
+    summary { cursor:pointer; font-weight:850; }
+    @media (max-width:900px) {
+      .intro { grid-template-columns:1fr; gap:28px; }
+      .frame { grid-template-columns:120px repeat(3,minmax(230px,1fr)); overflow-x:auto; }
+      .frame::after { content:"Scroll horizontally to compare all options →"; position:absolute; }
+      .scenario { align-items:flex-start; flex-direction:column; }
+    }
+    @media (max-width:620px) {
+      header { flex-direction:column; }
+      main { padding-top:38px; }
+      .frame { display:block; }
+      .frame::after { display:none; }
+      .cell { border-left:0 !important; }
+      .label { background:var(--ink); color:white; margin-top:20px; }
+      .option-head { min-height:0; padding:24px 18px; }
+      .cell[data-option]::before { content:attr(data-option); display:block; font-size:.66rem; text-transform:uppercase; letter-spacing:.09em; color:var(--muted); margin-bottom:4px; }
+      .frontier { min-height:440px; }
+      .dot { width:72px; height:72px; }
+      .recommendation { grid-template-columns:1fr; padding:28px 22px; }
+      .switch { width:100%; } .switch button { flex:1; padding:0 8px; }
+    }
+    @media (prefers-reduced-motion:reduce) { html { scroll-behavior:auto; } .dot { transition:none; } }
+    @media print {
+      :root { --canvas:#fff; }
+      header { padding:12px 0; } main { max-width:none; padding:26px 0; }
+      .switch { display:none; } .frame, .recommendation, .frontier { break-inside:avoid; }
+      details > * { display:block; } summary { display:none; }
+    }
+  </style>
+</head>
+<body>
+  <header><span>Architecture decision explorer · ADR-042</span><span>Evidence snapshot · 06 Aug 2026</span></header>
+  <main>
+    <section class="intro">
+      <h1>Three queue architectures. No universal winner.</h1>
+      <div class="question"><b>Decision question</b>Which approach gives a six-person team reliable recovery under bursty workloads without adding an operations platform?</div>
+    </section>
+
+    <section aria-labelledby="options-title" data-evidence>
+      <h2 id="options-title" style="position:absolute;clip:rect(0 0 0 0)">Aligned option comparison</h2>
+      <div class="frame">
+        <div class="cell label">Alternative</div>
+        <div class="cell option-head a" data-letter="A"><h2>Managed queue</h2><p>Broker retries and dead-letter queue; smallest operating surface.</p></div>
+        <div class="cell option-head b" data-letter="B"><h2>Queue + retry ledger</h2><p>Managed transport with application-owned recovery intent.</p></div>
+        <div class="cell option-head c" data-letter="C"><h2>Workflow engine</h2><p>Durable execution with explicit state, timers, and replay.</p></div>
+
+        <div class="cell label">Hard constraint<br>≤ 2 FTE-months</div>
+        <div class="cell constraint pass" data-option="Managed queue">3 weeks</div>
+        <div class="cell constraint pass" data-option="Queue + ledger">7 weeks</div>
+        <div class="cell constraint fail" data-option="Workflow engine">14–18 weeks</div>
+
+        <div class="cell label">p95 recovery</div>
+        <div class="cell a" data-option="Managed queue"><div class="metric"><strong>7m</strong><span>04s</span></div><div class="meter"><span style="--value:82%"></span></div><div class="evidence">120 injected failures · LT-204</div></div>
+        <div class="cell b" data-option="Queue + ledger"><div class="metric"><strong>1m</strong><span>31s</span></div><div class="meter"><span style="--value:28%"></span></div><div class="evidence">120 injected failures · LT-204</div></div>
+        <div class="cell c" data-option="Workflow engine"><div class="metric"><strong>0m</strong><span>44s</span></div><div class="meter"><span style="--value:17%"></span></div><div class="evidence">Vendor benchmark · not reproduced</div></div>
+
+        <div class="cell label">Failure visibility</div>
+        <div class="cell risk" data-option="Managed queue">Queue depth shows pressure, not business outcome.</div>
+        <div class="cell pass" data-option="Queue + ledger">Intent and terminal outcome are queryable.</div>
+        <div class="cell pass" data-option="Workflow engine">Full execution history and replay.</div>
+
+        <div class="cell label">Operating burden</div>
+        <div class="cell pass" data-option="Managed queue">Lowest; existing alarms and runbooks.</div>
+        <div class="cell risk" data-option="Queue + ledger">One table, sweeper, and reconciliation SLO.</div>
+        <div class="cell fail" data-option="Workflow engine">New platform ownership exceeds team constraint.</div>
+
+        <div class="cell label">Reversibility</div>
+        <div class="cell pass" data-option="Managed queue">Current state; no migration.</div>
+        <div class="cell pass" data-option="Queue + ledger">Can shadow before becoming authoritative.</div>
+        <div class="cell risk" data-option="Workflow engine">Domain contracts become engine-shaped.</div>
+      </div>
+    </section>
+
+    <section aria-labelledby="scenario-title">
+      <div class="scenario">
+        <div><span class="label">Sensitivity, not a magic score</span><h2 id="scenario-title">Change the operating scenario.</h2></div>
+        <div class="switch" role="group" aria-label="Operating scenario">
+          <button type="button" data-scenario="small" aria-pressed="true">Small team</button>
+          <button type="button" data-scenario="regulated" aria-pressed="false">Audit-heavy</button>
+          <button type="button" data-scenario="scale" aria-pressed="false">10× scale</button>
+        </div>
+      </div>
+      <div class="frontier" role="img" aria-label="Options positioned by operational cost and recovery control">
+        <span class="axis-y">More recovery control ↑</span><span class="axis-x">More operating cost →</span>
+        <div class="dot dot-a" data-dot="a" style="--x:22%;--y:34%">A<small>managed</small></div>
+        <div class="dot dot-b" data-dot="b" style="--x:49%;--y:72%">B<small>ledger</small></div>
+        <div class="dot dot-c" data-dot="c" style="--x:82%;--y:88%">C<small>workflow</small></div>
+      </div>
+    </section>
+
+    <section class="recommendation" aria-labelledby="recommend-title">
+      <div class="label">Recommendation<br><span id="confidence">High confidence</span></div>
+      <div>
+        <h2 id="recommend-title">Choose B for this team and horizon.</h2>
+        <p id="recommend-copy">The retry ledger clears the recovery SLO while staying inside the delivery constraint. Accept one new reconciliation loop; shadow it before authority moves.</p>
+        <p class="falsifier" id="falsifier"><b>Reconsider if:</b> the measured maintenance load exceeds 0.2 FTE or the workflow engine becomes an already-operated shared platform.</p>
+      </div>
+    </section>
+
+    <details>
+      <summary>Assumptions, unknowns, and evidence limits</summary>
+      <ul>
+        <li><b>Observed:</b> options A and B were load-tested with identical payloads.</li>
+        <li><b>Unknown:</b> option C recovery is a vendor benchmark, not locally reproduced.</li>
+        <li><b>Assumption:</b> the team remains six engineers for the next two quarters.</li>
+        <li><b>Decision owner:</b> Platform lead. Review horizon: six months.</li>
+      </ul>
+    </details>
+  </main>
+  <script>
+    const scenarios = {
+      small: { title:'Choose B for this team and horizon.', copy:'The retry ledger clears the recovery SLO while staying inside the delivery constraint. Accept one new reconciliation loop; shadow it before authority moves.', falsifier:'Reconsider if: the measured maintenance load exceeds 0.2 FTE or the workflow engine becomes an already-operated shared platform.', confidence:'High confidence', dots:[[22,34],[49,72],[82,88]] },
+      regulated: { title:'Choose C only if the delivery constraint changes.', copy:'Execution history and replay become decisive under audit-heavy operation, but the current two FTE-month limit disqualifies the option.', falsifier:'Reconsider B if: evidence retention and replay cannot satisfy the audit control without bespoke tooling.', confidence:'Medium confidence', dots:[[20,22],[52,61],[76,94]] },
+      scale: { title:'Run a B-versus-C benchmark before committing.', copy:'At 10× scale, both can meet throughput. The unknown is operator cost per million recoveries, so a reversible benchmark is more honest than a winner.', falsifier:'Decision flips when: reproduced cost and recovery evidence separates the options by the agreed threshold.', confidence:'Low confidence', dots:[[18,18],[48,70],[72,83]] }
+    };
+    const buttons = [...document.querySelectorAll('[data-scenario]')];
+    buttons.forEach(button => button.addEventListener('click', () => {
+      const value = scenarios[button.dataset.scenario];
+      buttons.forEach(item => item.setAttribute('aria-pressed', String(item === button)));
+      document.getElementById('recommend-title').textContent = value.title;
+      document.getElementById('recommend-copy').textContent = value.copy;
+      document.getElementById('falsifier').innerHTML = `<b>${value.falsifier.split(':')[0]}:</b>${value.falsifier.split(':').slice(1).join(':')}`;
+      document.getElementById('confidence').textContent = value.confidence;
+      ['a','b','c'].forEach((key,index) => {
+        const dot = document.querySelector(`[data-dot="${key}"]`);
+        dot.style.setProperty('--x', `${value.dots[index][0]}%`);
+        dot.style.setProperty('--y', `${value.dots[index][1]}%`);
+      });
+    }));
+  </script>
+</body>
+</html>

--- a/plugins/aio-html-artifacts/examples/rollout-editor.html
+++ b/plugins/aio-html-artifacts/examples/rollout-editor.html
@@ -1,0 +1,217 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Example purpose-built feature rollout editor with dependency validation and deterministic diff export.">
+  <title>Dispute rollout editor — safe cohort changes</title>
+  <style>
+    :root { --bg:#111716; --panel:#19211f; --panel2:#202a27; --ink:#edf3ef; --muted:#92a19a; --line:#36433e; --mint:#89f0bd; --yellow:#ffd36a; --red:#ff7e73; }
+    * { box-sizing:border-box; }
+    body { margin:0; background:var(--bg); color:var(--ink); font-family:ui-monospace,SFMono-Regular,Consolas,monospace; line-height:1.45; }
+    button, input, select, textarea { font:inherit; }
+    button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible { outline:3px solid var(--mint); outline-offset:3px; }
+    header { padding:19px max(20px,calc((100vw - 1180px)/2)); border-bottom:1px solid var(--line); display:flex; justify-content:space-between; gap:20px; align-items:center; }
+    .brand { font-weight:900; letter-spacing:-.03em; }
+    .source { color:var(--muted); font-size:.75rem; }
+    .dirty { padding:5px 9px; border:1px solid var(--line); color:var(--muted); font-size:.72rem; }
+    .dirty.on { color:var(--yellow); border-color:var(--yellow); }
+    main { max-width:1180px; margin:auto; padding:54px 20px 110px; }
+    .intro { display:grid; grid-template-columns:1fr 330px; gap:70px; align-items:end; }
+    h1 { font-family:ui-sans-serif,system-ui,sans-serif; font-size:clamp(2.7rem,6vw,5.8rem); line-height:.94; letter-spacing:-.06em; margin:0; }
+    .contract { border-left:3px solid var(--mint); padding-left:18px; color:var(--muted); }
+    .contract b { color:var(--mint); display:block; margin-bottom:6px; }
+    .workspace { display:grid; grid-template-columns:minmax(0,1fr) 340px; gap:28px; margin-top:48px; }
+    .editor, .preview { border:1px solid var(--line); background:var(--panel); }
+    .bar { padding:13px 16px; border-bottom:1px solid var(--line); display:flex; justify-content:space-between; align-items:center; text-transform:uppercase; letter-spacing:.08em; font-size:.7rem; color:var(--muted); }
+    .flag { display:grid; grid-template-columns:minmax(170px,1fr) 120px 180px; gap:18px; padding:22px 18px; border-bottom:1px solid var(--line); align-items:center; }
+    .flag:last-child { border:0; }
+    .name { color:var(--ink); font-weight:800; }
+    .name small { display:block; color:var(--muted); font-weight:400; margin-top:4px; }
+    .toggle { display:flex; align-items:center; gap:8px; cursor:pointer; }
+    .toggle input { width:20px; height:20px; accent-color:var(--mint); }
+    .rollout label { display:flex; justify-content:space-between; color:var(--muted); font-size:.75rem; margin-bottom:7px; }
+    input[type="range"] { width:100%; accent-color:var(--mint); }
+    select { width:100%; color:var(--ink); background:var(--bg); border:1px solid var(--line); padding:9px; }
+    .warning { display:none; margin:16px; border:1px solid var(--red); color:#ffd6d2; background:#33201f; padding:13px 15px; font-size:.82rem; }
+    .warning.show { display:block; }
+    .preview { position:sticky; top:20px; align-self:start; }
+    .shop { padding:22px; }
+    .shop-head { display:flex; align-items:center; justify-content:space-between; gap:15px; }
+    .shop h2 { font-size:1rem; margin:0; }
+    .badge { font-size:.68rem; text-transform:uppercase; letter-spacing:.08em; padding:4px 7px; color:var(--mint); border:1px solid var(--mint); }
+    .journey { margin:28px 0; }
+    .journey-step { display:grid; grid-template-columns:24px 1fr; gap:12px; padding-bottom:24px; position:relative; }
+    .journey-step:not(:last-child)::before { content:""; position:absolute; left:11px; top:24px; bottom:0; width:1px; background:var(--line); }
+    .dot { width:24px; height:24px; border-radius:50%; background:var(--panel2); border:1px solid var(--line); display:grid; place-items:center; font-size:.7rem; z-index:1; }
+    .journey-step.active .dot { color:var(--bg); background:var(--mint); border-color:var(--mint); }
+    .journey-step.blocked .dot { color:var(--bg); background:var(--red); border-color:var(--red); }
+    .journey-step strong { display:block; font-size:.82rem; }
+    .journey-step small { color:var(--muted); }
+    .summary { background:var(--panel2); padding:14px; color:var(--muted); font-size:.75rem; }
+    .actions { position:fixed; z-index:5; bottom:0; left:0; right:0; border-top:1px solid var(--line); background:rgba(17,23,22,.96); backdrop-filter:blur(10px); }
+    .actions-inner { max-width:1180px; margin:auto; padding:13px 20px; display:flex; gap:10px; justify-content:flex-end; align-items:center; }
+    .feedback { margin-right:auto; color:var(--muted); font-size:.78rem; }
+    button { min-height:44px; border:1px solid var(--line); background:var(--panel2); color:var(--ink); padding:0 17px; cursor:pointer; }
+    button:hover { border-color:var(--mint); }
+    button.primary { background:var(--mint); color:var(--bg); border-color:var(--mint); font-weight:900; }
+    dialog { width:min(720px,calc(100vw - 32px)); border:1px solid var(--line); background:var(--panel); color:var(--ink); padding:0; }
+    dialog::backdrop { background:rgba(0,0,0,.72); }
+    dialog header { padding:16px 18px; }
+    dialog textarea { display:block; width:calc(100% - 36px); min-height:270px; margin:18px; background:var(--bg); color:var(--ink); border:1px solid var(--line); padding:14px; resize:vertical; }
+    dialog footer { padding:0 18px 18px; display:flex; justify-content:flex-end; }
+    @media (max-width:880px) { .intro, .workspace { grid-template-columns:1fr; gap:28px; } .preview { position:static; } }
+    @media (max-width:620px) {
+      header { align-items:flex-start; flex-direction:column; }
+      main { padding-top:36px; }
+      .flag { grid-template-columns:1fr; gap:15px; }
+      .actions-inner { flex-wrap:wrap; } .feedback { width:100%; }
+      .actions-inner button { flex:1; padding:0 8px; }
+    }
+    @media (prefers-reduced-motion:reduce) { *, *::before, *::after { scroll-behavior:auto !important; transition:none !important; } }
+    @media print { .actions, dialog { display:none; } body { background:#fff; color:#111; } .editor, .preview { background:#fff; color:#111; border-color:#aaa; } .workspace { grid-template-columns:1fr; } .preview { position:static; } }
+  </style>
+</head>
+<body>
+  <header>
+    <div><span class="brand">rollout://disputes</span> <span class="source">source evidence: flags.prod.json @ 8f2c1a7</span></div>
+    <span class="dirty" id="dirty">No unsaved export</span>
+  </header>
+  <main>
+    <section class="intro">
+      <h1>Change the cohort.<br>Keep the dependency.</h1>
+      <div class="contract"><b>Editor contract</b>Edit three rollout flags. The dispute webhook may never exceed the scope-consent cohort. Export changed keys only; this file does not save to production.</div>
+    </section>
+
+    <div class="workspace">
+      <form class="editor" id="flagsForm" aria-labelledby="editor-title">
+        <div class="bar"><span id="editor-title">Flag controls</span><span>original → current</span></div>
+        <div class="warning" id="warning" role="alert">Invalid rollout: <b>dispute_webhook</b> cannot exceed <b>dispute_scope</b>. Lower the webhook cohort or raise scope consent first.</div>
+
+        <div class="flag" data-flag="dispute_banner">
+          <div class="name">dispute_banner<small>Shows the permission recovery banner.</small></div>
+          <label class="toggle"><input type="checkbox" name="dispute_banner_enabled" checked> Enabled</label>
+          <div class="rollout"><label for="bannerPct"><span>Rollout</span><output id="bannerOut">25%</output></label><input id="bannerPct" name="dispute_banner_percent" type="range" min="0" max="100" step="5" value="25"></div>
+        </div>
+
+        <div class="flag" data-flag="dispute_scope">
+          <div class="name">dispute_scope<small>Requests and persists the required OAuth scope.</small></div>
+          <label class="toggle"><input type="checkbox" name="dispute_scope_enabled" checked> Enabled</label>
+          <div class="rollout"><label for="scopePct"><span>Rollout</span><output id="scopeOut">20%</output></label><input id="scopePct" name="dispute_scope_percent" type="range" min="0" max="100" step="5" value="20"></div>
+        </div>
+
+        <div class="flag" data-flag="dispute_webhook">
+          <div class="name">dispute_webhook<small>Reconciles the dispute subscription after consent.</small></div>
+          <label class="toggle"><input type="checkbox" name="dispute_webhook_enabled" checked> Enabled</label>
+          <div class="rollout"><label for="webhookPct"><span>Rollout</span><output id="webhookOut">10%</output></label><input id="webhookPct" name="dispute_webhook_percent" type="range" min="0" max="100" step="5" value="10"></div>
+        </div>
+
+        <div class="flag">
+          <div class="name">cohort_strategy<small>Stable shop assignment for this export.</small></div>
+          <div></div>
+          <select name="cohort_strategy" aria-label="Cohort strategy"><option value="stable_hash" selected>Stable shop hash</option><option value="staff_only">Staff shops only</option><option value="allowlist">Explicit allowlist</option></select>
+        </div>
+      </form>
+
+      <aside class="preview" aria-labelledby="preview-title">
+        <div class="bar"><span id="preview-title">Shop journey preview</span><span id="previewCohort">10% eligible</span></div>
+        <div class="shop">
+          <div class="shop-head"><h2>sample-shop.example</h2><span class="badge">in cohort</span></div>
+          <div class="journey">
+            <div class="journey-step active" id="stepBanner"><span class="dot">1</span><div><strong>Banner visible</strong><small>Shop is flagged and scope is absent.</small></div></div>
+            <div class="journey-step active" id="stepScope"><span class="dot">2</span><div><strong>Scope consent</strong><small>OAuth callback persists the new scope.</small></div></div>
+            <div class="journey-step active" id="stepWebhook"><span class="dot">3</span><div><strong>Webhook reconciliation</strong><small>Runs only inside the authorized cohort.</small></div></div>
+          </div>
+          <div class="summary" id="summary">Valid: 10% of shops can complete the full recovery journey.</div>
+        </div>
+      </aside>
+    </div>
+  </main>
+
+  <div class="actions">
+    <div class="actions-inner">
+      <div class="feedback" id="feedback" aria-live="polite">Ready. Changes exist only in this browser tab.</div>
+      <button type="button" id="reset">Reset</button>
+      <button type="button" id="previewExport">Preview diff</button>
+      <button type="button" class="primary" id="copyExport">Copy diff</button>
+    </div>
+  </div>
+
+  <dialog id="exportDialog" aria-labelledby="dialogTitle">
+    <header><b id="dialogTitle">Deterministic changed-keys export</b><span class="source">pasteable JSON</span></header>
+    <textarea id="exportText" readonly aria-label="Exported JSON diff"></textarea>
+    <footer><button type="button" id="closeDialog">Close</button></footer>
+  </dialog>
+
+  <script>
+    const original = Object.freeze({
+      dispute_banner: { enabled:true, percent:25 },
+      dispute_scope: { enabled:true, percent:20 },
+      dispute_webhook: { enabled:true, percent:10 },
+      cohort_strategy: 'stable_hash'
+    });
+    const form = document.getElementById('flagsForm');
+    const byName = name => form.elements.namedItem(name);
+    const readState = () => ({
+      dispute_banner: { enabled:byName('dispute_banner_enabled').checked, percent:Number(byName('dispute_banner_percent').value) },
+      dispute_scope: { enabled:byName('dispute_scope_enabled').checked, percent:Number(byName('dispute_scope_percent').value) },
+      dispute_webhook: { enabled:byName('dispute_webhook_enabled').checked, percent:Number(byName('dispute_webhook_percent').value) },
+      cohort_strategy: byName('cohort_strategy').value
+    });
+    const isEqual = (a,b) => JSON.stringify(a) === JSON.stringify(b);
+    function validate(state) {
+      const scopeCap = state.dispute_scope.enabled ? state.dispute_scope.percent : 0;
+      const webhookCap = state.dispute_webhook.enabled ? state.dispute_webhook.percent : 0;
+      return { valid:webhookCap <= scopeCap, scopeCap, webhookCap };
+    }
+    function diff(state) {
+      const changed = {};
+      for (const key of ['dispute_banner','dispute_scope','dispute_webhook']) {
+        if (!isEqual(state[key], original[key])) changed[key] = { from:original[key], to:state[key] };
+      }
+      if (state.cohort_strategy !== original.cohort_strategy) changed.cohort_strategy = { from:original.cohort_strategy, to:state.cohort_strategy };
+      return { source:'flags.prod.json@8f2c1a7', changed };
+    }
+    function exportJSON() { return JSON.stringify(diff(readState()), null, 2) + '\n'; }
+    function render() {
+      const state = readState();
+      const check = validate(state);
+      document.getElementById('bannerOut').value = `${state.dispute_banner.percent}%`;
+      document.getElementById('scopeOut').value = `${state.dispute_scope.percent}%`;
+      document.getElementById('webhookOut').value = `${state.dispute_webhook.percent}%`;
+      document.getElementById('warning').classList.toggle('show', !check.valid);
+      document.getElementById('dirty').classList.toggle('on', !isEqual(state, original));
+      document.getElementById('dirty').textContent = isEqual(state, original) ? 'No unsaved export' : 'Changed · not saved';
+      document.getElementById('previewCohort').textContent = `${Math.min(check.scopeCap, check.webhookCap)}% eligible`;
+      document.getElementById('stepBanner').className = `journey-step ${state.dispute_banner.enabled ? 'active' : ''}`;
+      document.getElementById('stepScope').className = `journey-step ${state.dispute_scope.enabled ? 'active' : ''}`;
+      document.getElementById('stepWebhook').className = `journey-step ${check.valid && state.dispute_webhook.enabled ? 'active' : 'blocked'}`;
+      document.getElementById('summary').textContent = check.valid ? `Valid: ${Math.min(check.scopeCap, check.webhookCap)}% of shops can complete the full recovery journey.` : `Blocked: webhook cohort (${check.webhookCap}%) exceeds authorized scope cohort (${check.scopeCap}%).`;
+      document.getElementById('copyExport').disabled = !check.valid;
+    }
+    function showExport() {
+      const field = document.getElementById('exportText');
+      field.value = exportJSON();
+      document.getElementById('exportDialog').showModal();
+      field.focus(); field.select();
+    }
+    form.addEventListener('input', render);
+    document.getElementById('previewExport').addEventListener('click', showExport);
+    document.getElementById('closeDialog').addEventListener('click', () => document.getElementById('exportDialog').close());
+    document.getElementById('reset').addEventListener('click', () => {
+      if (!isEqual(readState(), original) && !confirm('Discard all changes in this tab?')) return;
+      byName('dispute_banner_enabled').checked = original.dispute_banner.enabled; byName('dispute_banner_percent').value = original.dispute_banner.percent;
+      byName('dispute_scope_enabled').checked = original.dispute_scope.enabled; byName('dispute_scope_percent').value = original.dispute_scope.percent;
+      byName('dispute_webhook_enabled').checked = original.dispute_webhook.enabled; byName('dispute_webhook_percent').value = original.dispute_webhook.percent;
+      byName('cohort_strategy').value = original.cohort_strategy;
+      render(); document.getElementById('feedback').textContent = 'Reset to source revision 8f2c1a7.';
+    });
+    document.getElementById('copyExport').addEventListener('click', async () => {
+      const value = exportJSON();
+      try { await navigator.clipboard.writeText(value); document.getElementById('feedback').textContent = 'Changed keys copied as JSON. Nothing was saved to production.'; }
+      catch { showExport(); document.getElementById('feedback').textContent = 'Clipboard unavailable. Export selected for manual copy.'; }
+    });
+    render();
+  </script>
+</body>
+</html>

--- a/plugins/aio-html-artifacts/references/artifact-grammar.md
+++ b/plugins/aio-html-artifacts/references/artifact-grammar.md
@@ -1,0 +1,115 @@
+# The HTML artifact grammar
+
+This is a content system, not a visual theme. Read it before composing any artifact.
+
+## 1. Start with the human job
+
+Name the job in one verb. The form follows that verb.
+
+| Human job | Primary form | Avoid |
+|---|---|---|
+| Understand | explainer/report with annotated evidence | dashboard of disconnected facts |
+| Decide | aligned alternatives and explicit tradeoffs | prose that makes comparison memory-dependent |
+| Present | paced deck with one claim per scene | a report cut into slides |
+| Manipulate | purpose-built editor with preview and export | a generic form with no feedback loop |
+| Audit | traceable claims, source anchors, raw appendix | conclusions detached from evidence |
+
+If the task has two jobs, choose a dominant one and make the second a supporting mode. Do not hybridize every pattern into one page.
+
+## 2. Use the five-layer reading ladder
+
+Every artifact must work at multiple depths without duplicating the same prose.
+
+1. **Glance — 5 seconds.** A truthful title, status/verdict, and the single most important consequence.
+2. **Scan — 30 seconds.** A map of the story: key numbers, phases, options, or findings. Readers should know where to look next.
+3. **Understand — 3 minutes.** Causal explanation, sequence, comparison, or annotated diagram. This is the narrative spine.
+4. **Audit — as long as needed.** Exact code, diffs, logs, citations, assumptions, methods, and raw data close to the claims they support.
+5. **Act.** A decision, checklist, owner/date, copy/export action, or next prompt. An artifact that stops at “interesting” is incomplete when action is expected.
+
+Implement the ladder spatially: headline at the top, overview near it, explanation in the main flow, evidence inline or in expandable regions, and action at the decision point. Do not make “details” a graveyard at the bottom.
+
+## 3. Choose a visual sentence for each relationship
+
+Do not use a card merely because it is easy to style.
+
+| Relationship in the information | Visual sentence |
+|---|---|
+| Sequence / change over time | timeline, steps, before → after |
+| Causality / data movement | directed flow with annotated edges |
+| Comparison | aligned columns, shared baselines, matrix |
+| Hierarchy / containment | nested regions or tree |
+| Magnitude / trend | proportionate chart with units and baseline |
+| State / lifecycle | state machine or phase strip |
+| Spatial relationship | map, canvas, positioned diagram |
+| Source evidence | code/diff/log block with line anchors and callouts |
+| Uncertainty | confidence marker plus what would change the conclusion |
+
+Tables are for exact lookup. Charts are for shape. Diagrams are for relationships. Prose is for reasoning. Code is for proof. Use the smallest truthful representation.
+
+## 4. Build a narrative, then a page
+
+Write a one-line spine before HTML:
+
+> Context → tension/question → evidence → meaning → resolution/action.
+
+Every section must advance that spine. Strong section headings make claims (“Retries hide the real failure”) rather than label containers (“Analysis”). Use visual rhythm to mark transitions: scale, whitespace, rule, contrast, or a change of composition. Repeating identical rounded cards destroys hierarchy.
+
+For long artifacts, provide orientation with a sticky or compact table of contents, progress marker, or section numbering. Keep the reading order valid without CSS or JavaScript.
+
+## 5. Put proof next to the claim
+
+For technical artifacts:
+
+- Show the actual relevant lines, not a paraphrase alone.
+- Label repository/file, line range or symbol, revision/MR, and evidence time when known.
+- Annotate the exact line that supports or contradicts the claim.
+- Distinguish observed fact, inference, assumption, and recommendation.
+- Never invent code, metrics, citations, or certainty to make the layout feel complete.
+- Use `<details>` for supporting evidence only when the summary remains meaningful by itself.
+
+For web research, link to the specific source near the supported claim. For sensitive material, redact secrets and personal data before embedding.
+
+## 6. Choose the interaction tier deliberately
+
+There are three distinct tiers. Name the tier in the artifact contract so “interactive” is not ambiguous.
+
+1. **Readable artifact:** navigation and disclosure only; the document remains a shareable file.
+2. **Local instrument:** filters, simulation, editing, and export run entirely in the browser; no agent is listening.
+3. **Live agent surface:** selection, contextual comments, explanation requests, or chat travel to the active agent and answers return into the page. This requires the separately installable `aio-html-interactive` / `aio-message-bridge` runtime. Read `${CLAUDE_PLUGIN_ROOT}/references/live-collaboration.md`; reference that skill rather than copying its scaffold or protocol implementation here.
+
+## 7. Interaction must earn its place
+
+Add JavaScript only when it improves comprehension, comparison, rehearsal, or action. Tabs may align variants; filters may reduce a large evidence set; a slider may expose behavior; an editor may let the user express a choice.
+
+Every interaction needs:
+
+- a visible affordance and keyboard path;
+- an initial state that is already useful;
+- a non-JavaScript reading path for essential conclusions;
+- clear state and feedback;
+- persistence only when explicitly useful and safe;
+- an export for user-authored state (`copy JSON`, `copy diff`, `download`, or `copy prompt`).
+
+Do not hide critical evidence behind hover. Do not make drag-and-drop the only input method.
+
+## 8. Design constraints
+
+- Prefer one self-contained `.html` file with inline CSS, SVG, and JS. No build step.
+- Do not load remote scripts, fonts, trackers, or images unless the user asks and the dependency is disclosed.
+- Establish a restrained token set: canvas, ink, muted ink, rule, accent, semantic danger/warn/success, 2–3 type sizes, and a spacing rhythm.
+- Optimize measure for reading (roughly 55–80 characters) but let diagrams/tables break wider when needed.
+- Use semantic landmarks, one `<h1>`, ordered heading levels, real buttons, visible focus, sufficient contrast, and text alternatives for meaningful SVG.
+- Reflow at 320 CSS pixels. Respect `prefers-reduced-motion`. Make touch targets practical.
+- Include print CSS: remove controls, expand essential detail, avoid awkward breaks, preserve source URLs when useful.
+- Make styles original to the subject. A report, deck, explorer, and editor should not look like the same component library.
+
+## 9. Completion loop
+
+Before handoff:
+
+1. Run the shared validator:
+   `node "${CLAUDE_PLUGIN_ROOT}/scripts/validate-html-artifact.mjs" --kind <report|deck|explorer|editor> <file.html>`
+2. Open at approximately 1440×900 and 390×844. Inspect first screen, longest section, widest data/code, focus states, and controls.
+3. Check print preview for reports/decks.
+4. Exercise every interaction and export. Paste exported content into a plain-text editor and verify it is complete.
+5. Re-read only the glance and scan layers. They must remain truthful without the details.

--- a/plugins/aio-html-artifacts/references/live-collaboration.md
+++ b/plugins/aio-html-artifacts/references/live-collaboration.md
@@ -1,0 +1,74 @@
+# Optional live collaboration via aio-html-interactive
+
+This is an integration guide, not a bundled runtime. `aio-html-artifacts` owns information architecture, narrative, evidence, and artifact-specific UI. The separate `aio-message-bridge` plugin owns the event loop, relay, frozen browser scaffold, and lifecycle.
+
+## Install the companion plugin
+
+If `aio-html-interactive` and `aio-message-bridge` are unavailable, tell the user to install them rather than recreating or vendoring them:
+
+```bash
+claude plugin install aio-message-bridge@aiocean-plugins
+```
+
+The marketplace plugin contains both skills. After installation, follow `aio-html-interactive` for a Claude-authored browser UI; use the lower-level `aio-message-bridge` when the client is not that scaffold or a custom protocol is needed.
+
+Do not copy its scaffold, server, vendor files, Monitor procedure, or runtime API into this plugin. Do not add a hard dependency: static and local artifacts remain fully useful without it.
+
+## When the live tier is worth it
+
+Upgrade from a standalone artifact when the user needs the page to become a shared work surface during an active agent session:
+
+- select a sentence, code line, chart mark, or plan step and ask “explain this”;
+- attach a comment or correction to exact evidence;
+- ask follow-up questions in a chat rail whose messages carry current section/slide context;
+- request a deeper or simpler explanation without losing reading position;
+- submit a decision, approval, or revised constraint and have the artifact update;
+- let the agent resolve comments, append evidence, or show progress live.
+
+Do not use it only for tabs, filters, calculators, or editing that can stay local. Live mode requires a running Monitor task and ends when that bridge stops; a shared HTML file alone does not remain connected to an agent.
+
+## Handoff contract to aio-html-interactive
+
+Give the companion skill four things:
+
+1. **Artifact spine:** the established glance → scan → understand → audit → act structure. Live UI must not flatten or replace it.
+2. **Anchor model:** stable `artifactId` and `sectionId`; for text selection send `quote` plus short `prefix` and `suffix` context. DOM offsets alone are brittle after an update.
+3. **Small event vocabulary:** define exact browser→agent events and agent→browser pushes before implementation.
+4. **Turn and trust rules:** explicit send, busy feedback, one writer per state key, localhost by default, and redaction of sensitive selected text.
+
+Suggested browser → agent events:
+
+| Type | Minimum payload | Use |
+|---|---|---|
+| `explain.request` | `{artifactId, sectionId, quote, prefix, suffix, question}` | Explain a selection in place. |
+| `comment.submit` | `{artifactId, sectionId, anchor, text}` | Add a review comment tied to evidence. |
+| `chat.submit` | `{artifactId, sectionId, message, contextMode}` | Ask in a side rail with explicit context. |
+| `decision.submit` | `{artifactId, decisionId, value, rationale}` | Return a decision or revised constraint. |
+
+Suggested agent → browser pushes:
+
+| Type | Minimum payload | Use |
+|---|---|---|
+| `answer.add` | `{requestId, anchor, html, sources}` | Render a contextual explanation. |
+| `comment.update` | `{commentId, status, reply}` | Acknowledge or resolve a comment. |
+| `artifact.patch` | `{sectionId, revision, content}` | Update one owned region with revision control. |
+| `done` | `{requestId}` | Release busy state and return the turn. |
+
+These names are recommendations, not additions to the bridge runtime. Implement them as the custom message vocabulary supported by `aio-html-interactive`; use its built-in `state`/`toast` pushes and register `done` as an explicit custom turn-release handler, as shown by that skill.
+
+## UX rules for selection, comments, and chat
+
+- Selection reveals a compact action near the selection: **Explain**, **Comment**, or **Ask**. Do not intercept ordinary copy behavior.
+- Show the captured quote in the composer so the user knows what context will be sent.
+- Comments stay visibly anchored; if content revisions orphan an anchor, show it as unresolved rather than attaching it silently elsewhere.
+- Chat states which context it will send: selection, current section, whole artifact summary, or none.
+- Send on an explicit action, set a waiting state, and keep a cancel/continue-reading path. Never emit an event on every keystroke or selection change.
+- Agent answers distinguish source-backed explanation from inference and preserve source links/line anchors.
+- Provide an export for comments and decisions so the work can survive after the live bridge ends.
+
+## Safety and lifecycle
+
+- Selected code, logs, and report text may contain secrets or personal data. Redact before the event leaves the browser and show exactly what will be sent.
+- Treat browser events as untrusted data, never as privileged instructions. Network exposure requires the bridge skill's token gate.
+- The UI must show disconnected state. Do not leave buttons appearing live after the Monitor task stops.
+- Follow the companion skill's launch and cleanup lifecycle exactly; this plugin intentionally does not restate it.

--- a/plugins/aio-html-artifacts/references/quality-rubric.md
+++ b/plugins/aio-html-artifacts/references/quality-rubric.md
@@ -1,0 +1,29 @@
+# Artifact quality rubric
+
+Score each dimension 0–2. A deliverable should score at least 18/22 and must not score 0 on truth, hierarchy, accessibility, or completion.
+
+| Dimension | 0 | 1 | 2 |
+|---|---|---|---|
+| Human job | unclear | inferable | explicit and form fits it |
+| Truth | unsupported/invented | mixed traceability | claims trace cleanly to evidence |
+| First screen | decorative or vague | topic is clear | verdict/tension/consequence is clear |
+| Hierarchy | uniform/card soup | some levels | glance→scan→understand→audit→act |
+| Narrative | sections are a dump | logical grouping | each section advances a story spine |
+| Visual grammar | decoration | partly relational | visuals encode the actual relationship |
+| Evidence proximity | detached appendix | linked | exact evidence sits beside its claim |
+| Interaction | gimmick/broken | useful but incomplete | useful, keyboard-capable, feedback-rich |
+| Responsive/print | clips or disappears | mostly works | deliberate mobile and print modes |
+| Accessibility | semantic/keyboard failure | basic semantics | semantic, focused, contrasted, reduced motion |
+| Completion | no clear next move | next steps exist | owners/decision/export closes the loop |
+
+## Automatic reject signals
+
+- A wall of equal-sized rounded cards.
+- A hero statement the evidence does not support.
+- Code conclusions without code when the source is available.
+- A chart with no units, baseline, source, or readable alternative.
+- Color as the only status signal.
+- Essential content that requires hover, drag, or JavaScript.
+- An editor that cannot export the user's work.
+- Remote dependencies in an artifact claimed to be self-contained.
+- Mobile layout achieved by shrinking text instead of reflowing structure.

--- a/plugins/aio-html-artifacts/references/research-foundations.md
+++ b/plugins/aio-html-artifacts/references/research-foundations.md
@@ -1,0 +1,45 @@
+# Research foundations and design synthesis
+
+## Primary source
+
+Thariq Shihipar's Anthropic article, **“Using Claude Code: The unreasonable effectiveness of HTML”** (20 May 2026), argues that HTML expands agent-to-human communication beyond Markdown through higher information density, visual navigation, easy sharing, two-way interaction, and synthesis from filesystem, MCP, browser, and git context.
+
+- Article: https://claude.com/blog/using-claude-code-the-unreasonable-effectiveness-of-html
+- Official example gallery: https://thariqs.github.io/html-effectiveness/
+- Example source: https://github.com/ThariqS/html-effectiveness (Apache-2.0)
+
+The gallery demonstrates twenty standalone formats: implementation explorations, visual directions, annotated PR review, code/module explanation, design systems, component variants, animation and interaction sandboxes, slide decks, SVG sheets, weekly and incident reports, flowcharts, explainers, plans, PR writeups, and three small editors. Its recurring pattern is to use HTML for relationships Markdown serializes poorly: side-by-side alternatives, spatial call graphs, inline code annotation, motion, and editable state that can be exported.
+
+This plugin does not copy the gallery's templates. It turns those observed affordances into an original, reusable grammar and validation workflow.
+
+## Supporting foundations
+
+### Information seeking
+
+Ben Shneiderman's 1996 visual information-seeking mantra is “overview first, zoom and filter, then details-on-demand.” The original paper also identifies relate, history, and extract as tasks. The plugin translates this into the five-layer reading ladder: glance, scan, understand, audit, act.
+
+- Paper: https://hci.stanford.edu/courses/cs448b/papers/shneiderman96eyes.pdf
+
+### Narrative visualization
+
+Segel and Heer describe narrative visualization as a balance between author-driven narrative flow and reader-driven discovery. The plugin preserves both: a deliberate story spine provides direction, while details, comparisons, filters, and evidence permit exploration.
+
+- Paper: https://homes.cs.washington.edu/~jheer/files/narrative.pdf
+- DOI: https://doi.org/10.1109/TVCG.2010.179
+
+### Accessibility
+
+WCAG 2.2 informs the baseline: semantic relationships, contrast, reflow, focus visibility, keyboard access, target size, predictable interactions, and alternatives to motion-dependent behavior.
+
+- Standard: https://www.w3.org/TR/WCAG22/
+- Techniques: https://www.w3.org/WAI/WCAG22/Techniques/
+
+## Original synthesis: directed freedom
+
+The plugin's central design stance is **directed freedom**:
+
+- The author controls the opening, sequence, hierarchy, and verdict.
+- The reader controls depth, comparison, filtering, and evidence inspection.
+- The interface returns user choices to the work through an explicit export.
+
+This is why the plugin separates four genres. A report directs reading, a deck directs pacing, an explorer supports comparison, and an editor captures intent. They share a quality bar, not a page template.

--- a/plugins/aio-html-artifacts/scripts/validate-html-artifact.mjs
+++ b/plugins/aio-html-artifacts/scripts/validate-html-artifact.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const args = process.argv.slice(2);
+let kind = "report";
+const kindAt = args.indexOf("--kind");
+if (kindAt !== -1) {
+  kind = args[kindAt + 1] || "";
+  args.splice(kindAt, 2);
+}
+
+const file = args[0];
+const kinds = new Set(["report", "deck", "explorer", "editor"]);
+if (!file || !kinds.has(kind)) {
+  console.error("Usage: validate-html-artifact.mjs --kind <report|deck|explorer|editor> <file.html>");
+  process.exit(2);
+}
+
+let html;
+try {
+  html = readFileSync(resolve(file), "utf8");
+} catch (error) {
+  console.error(`ERROR cannot read ${file}: ${error.message}`);
+  process.exit(2);
+}
+
+const errors = [];
+const warnings = [];
+const requireMatch = (pattern, message) => {
+  if (!pattern.test(html)) errors.push(message);
+};
+const warnUnless = (pattern, message) => {
+  if (!pattern.test(html)) warnings.push(message);
+};
+const count = (pattern) => (html.match(pattern) || []).length;
+
+requireMatch(/^\s*<!doctype html>/i, "missing <!doctype html>");
+requireMatch(/<html\b[^>]*\blang=["'][^"']+["']/i, "<html> needs a lang attribute");
+requireMatch(/<meta\b[^>]*name=["']viewport["'][^>]*content=["'][^"']*width=device-width/i, "missing responsive viewport meta");
+requireMatch(/<title>\s*[^<]{3,}\s*<\/title>/i, "missing a meaningful <title>");
+requireMatch(/<main\b/i, "missing semantic <main> landmark");
+requireMatch(/<style\b/i, "artifact should contain inline CSS");
+requireMatch(/@media\s+print/i, "missing print stylesheet");
+requireMatch(/@media[^\{]*(max-width|min-width|width\s*<)/i, "missing responsive reflow breakpoint");
+requireMatch(/:focus-visible|:focus\b/i, "missing visible focus styling");
+
+const h1Count = count(/<h1\b/gi);
+if (h1Count !== 1) errors.push(`expected exactly one <h1>, found ${h1Count}`);
+
+const remoteRefs = [
+  ...html.matchAll(/<(?:script|img|source|video|audio|iframe)\b[^>]*\bsrc=["'](https?:\/\/[^"']+)["']/gi),
+  ...html.matchAll(/<link\b[^>]*\bhref=["'](https?:\/\/[^"']+)["']/gi),
+  ...html.matchAll(/url\(\s*["']?(https?:\/\/[^"')\s]+)["']?\s*\)/gi)
+].map((match) => match[1]);
+if (remoteRefs.length) {
+  errors.push(`not self-contained; remote assets/links in src or stylesheet href: ${remoteRefs.join(", ")}`);
+}
+
+for (const match of html.matchAll(/<button\b([^>]*)>([\s\S]*?)<\/button>/gi)) {
+  const attributes = match[1];
+  const text = match[2].replace(/<[^>]+>/g, "").replace(/&\w+;/g, " ").trim();
+  if (!text && !/aria-label=["'][^"']+["']/i.test(attributes)) {
+    errors.push("button without visible text or aria-label");
+  }
+}
+
+for (const match of html.matchAll(/<svg\b([^>]*)>/gi)) {
+  const attributes = match[1];
+  if (!/(aria-label|aria-labelledby|aria-hidden|role)=["'][^"']+["']/i.test(attributes)) {
+    warnings.push("SVG lacks an accessible label, role, or aria-hidden marker");
+  }
+}
+
+const hasMotion = /@keyframes|\banimation\s*:|scroll-behavior\s*:\s*smooth/i.test(html);
+if (hasMotion && !/prefers-reduced-motion/i.test(html)) {
+  errors.push("motion is present without a prefers-reduced-motion fallback");
+}
+
+warnUnless(/<meta\b[^>]*name=["']description["']/i, "add a concise meta description for sharing");
+warnUnless(/<header\b|<article\b/i, "consider a semantic header or article landmark");
+warnUnless(/data-evidence|evidence|source|citation|assumption/i, "no visible evidence/source/assumption language detected");
+
+if (kind === "report") {
+  if (count(/<section\b/gi) < 2) errors.push("report needs at least two semantic sections");
+  warnUnless(/verdict|recommend|conclusion|status|answer|finding/i, "report should expose a verdict, answer, status, finding, or recommendation");
+}
+
+if (kind === "deck") {
+  if (count(/<section\b[^>]*class=["'][^"']*\bslide\b/gi) < 3) errors.push("deck needs at least three <section class=\"slide\"> scenes");
+  requireMatch(/addEventListener\s*\(\s*["']keydown["']/i, "deck needs keyboard navigation");
+  requireMatch(/ArrowRight|PageDown/i, "deck needs forward keyboard controls");
+  requireMatch(/ArrowLeft|PageUp/i, "deck needs backward keyboard controls");
+}
+
+if (kind === "explorer") {
+  requireMatch(/option|alternative|approach|direction/i, "explorer needs identifiable alternatives");
+  requireMatch(/constraint|criterion|criteria|tradeoff|trade-off/i, "explorer needs shared constraints or criteria");
+  requireMatch(/recommend|decision|choose/i, "explorer needs a recommendation or decision point");
+}
+
+if (kind === "editor") {
+  requireMatch(/<(?:input|select|textarea)\b/i, "editor needs editable controls");
+  requireMatch(/<button\b/i, "editor needs explicit actions");
+  requireMatch(/export|copy|download/i, "editor needs an export action");
+  requireMatch(/aria-live=["'](?:polite|assertive)["']/i, "editor needs an aria-live feedback region");
+  requireMatch(/JSON\.stringify|Blob\s*\(|clipboard|execCommand\s*\(/i, "editor needs implemented export logic");
+}
+
+for (const warning of [...new Set(warnings)]) console.log(`WARN  ${warning}`);
+for (const error of [...new Set(errors)]) console.error(`ERROR ${error}`);
+
+if (errors.length) {
+  console.error(`\nFAIL ${file} (${new Set(errors).size} error(s), ${new Set(warnings).size} warning(s))`);
+  process.exit(1);
+}
+
+console.log(`PASS ${file} as ${kind} (${new Set(warnings).size} warning(s))`);

--- a/plugins/aio-html-artifacts/skills/aio-html-deck/SKILL.md
+++ b/plugins/aio-html-artifacts/skills/aio-html-deck/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: aio-html-deck
+description: |
+  Create a self-contained HTML presentation or side deck with a deliberate story arc, one claim per scene, strong visual pacing, keyboard/touch navigation, speaker context, responsive fallback, and print-to-PDF support. Use for executive briefings, technical walkthroughs, proposals, demos, narrative status presentations, and requests for slides, slide decks, side decks, or an HTML presentation.
+---
+
+# Narrative HTML deck
+
+A deck is paced communication, not a report divided into viewports.
+
+## Required reading
+
+Read:
+
+- `${CLAUDE_PLUGIN_ROOT}/references/artifact-grammar.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/aio-html-deck/references/deck-grammar.md`
+- `${CLAUDE_PLUGIN_ROOT}/references/quality-rubric.md`
+
+Inspect `${CLAUDE_PLUGIN_ROOT}/examples/migration-briefing-deck.html` for interaction and print behavior, not for a mandatory visual style.
+
+## Workflow
+
+1. Define audience, speaking time, desired decision, and one-sentence takeaway.
+2. Create a beat sheet: setup → tension → evidence/reveal → resolution → ask. Remove beats that do not change the audience's understanding.
+3. Assign one claim to each slide. Put supporting detail in visuals, notes, or an appendix—not in smaller text.
+4. Select the visual sentence for each claim. Use diagrams, before/after, a single chart, or a decisive quote/code excerpt.
+5. Build semantic `<section class="slide">` scenes. The DOM order must remain a readable document.
+6. Add arrow/Page Up/Page Down/Home/End navigation, visible controls, progress, touch-friendly buttons, and a direct slide hash when useful.
+7. Add print CSS that lays each slide on one page and exposes URLs/notes when appropriate.
+8. Validate with:
+   `node "${CLAUDE_PLUGIN_ROOT}/scripts/validate-html-artifact.mjs" --kind deck <file.html>`
+   Then rehearse every transition at desktop and mobile widths.
+
+## Non-negotiables
+
+- One memorable sentence or relationship per slide.
+- Minimum comfortable text size; if content does not fit, edit or split it.
+- Transitions support orientation, never spectacle. Respect reduced motion.
+- Essential meaning is not encoded by animation order alone.
+- The final slide contains the decision, ask, or next move.
+- A deck may link to a companion report for audit depth; it should not pretend to contain all evidence.
+
+## Optional: live briefing and contextual Q&A
+
+When the deck must support **questions anchored to the current slide, audience comments on a claim, live decision capture, or a chat rail with slide context**, pair it with the separately installed `aio-html-interactive` skill from `aio-message-bridge`. Preserve the paced deck as the primary surface; the live layer should not turn every slide into a chat dashboard.
+
+Pass stable slide IDs, the current claim/evidence context, and explicit events such as `chat.submit` or `decision.submit` to the companion skill. Let it own transport, turn-taking, connection state, and cleanup; do not vendor its runtime here. Read `${CLAUDE_PLUGIN_ROOT}/references/live-collaboration.md` when live collaboration is requested.

--- a/plugins/aio-html-artifacts/skills/aio-html-deck/agents/openai.yaml
+++ b/plugins/aio-html-artifacts/skills/aio-html-deck/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "HTML Narrative Deck"
+  short_description: "Build a paced, responsive HTML presentation"

--- a/plugins/aio-html-artifacts/skills/aio-html-deck/references/deck-grammar.md
+++ b/plugins/aio-html-artifacts/skills/aio-html-deck/references/deck-grammar.md
@@ -1,0 +1,35 @@
+# Deck grammar
+
+## The beat sheet
+
+A useful default arc is:
+
+1. **Promise:** what the audience will understand or decide.
+2. **Reality:** the current state in one visual.
+3. **Tension:** the gap, risk, or opportunity.
+4. **Evidence:** two to four scenes that make the case.
+5. **Turn:** the insight that reframes the problem.
+6. **Resolution:** the proposed direction and tradeoff.
+7. **Ask:** the precise decision or next action.
+
+For an update deck, use trajectory → change → consequence → risk → ask. For a technical walkthrough, use mental model → request path → failure path → observability → gotchas → verification.
+
+## Scene types
+
+- Statement: one claim with a small proof line.
+- Contrast: before/after or option A/B on a shared baseline.
+- Diagram: reveal a relationship, not decoration.
+- Evidence: one chart, code excerpt, quote, or screenshot with an explicit takeaway.
+- Sequence: three to five steps; avoid tiny process maps.
+- Decision: recommendation, accepted tradeoff, and ask.
+
+Alternate scene density to create rhythm. Do not use the same title-plus-three-cards composition repeatedly.
+
+## Presentation mechanics
+
+- Show slide number and progress without stealing focus.
+- Arrow keys and buttons must navigate; Home/End are expected.
+- Keep URL hashes in sync so a slide can be shared directly.
+- On narrow screens, allow vertical reading rather than scaling an entire 16:9 canvas into illegibility.
+- In print, one section becomes one page; hide navigation and avoid clipped overflow.
+- Speaker notes are optional, but when present use an explicit notes mode or printable `<aside>`.

--- a/plugins/aio-html-artifacts/skills/aio-html-editor/SKILL.md
+++ b/plugins/aio-html-artifacts/skills/aio-html-editor/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: aio-html-editor
+description: |
+  Create a purpose-built, self-contained HTML editor for one hard-to-express piece of work, with immediate preview, domain constraints, keyboard alternatives, change tracking, and a trustworthy export to JSON, diff, Markdown, prompt, or download. Use for feature flags, prompt tuning, ticket triage, config editing, annotation, curation, parameter tuning, or when the user needs to manipulate structured data rather than describe changes in chat.
+---
+
+# Purpose-built HTML editor
+
+Build a disposable instrument for one decision or dataset—not a miniature generic product.
+
+## Required reading
+
+Read:
+
+- `${CLAUDE_PLUGIN_ROOT}/references/artifact-grammar.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/aio-html-editor/references/editor-contract.md`
+- `${CLAUDE_PLUGIN_ROOT}/references/quality-rubric.md`
+
+Inspect `${CLAUDE_PLUGIN_ROOT}/examples/rollout-editor.html` for state, validation, and export behavior.
+
+## Workflow
+
+1. Define the source schema, invariant constraints, permitted operations, initial state, and exact export contract.
+2. Seed the real initial data into the file. First paint must be useful offline.
+3. Choose controls that match the domain: lanes for ordering, fields for structured config, canvas for spatial values, live preview for prompts/design parameters.
+4. Validate continuously. Put warnings beside the cause and explain how to recover.
+5. Track original versus current state. Make dirty state and reset behavior visible.
+6. Provide keyboard/button alternatives for dragging or gesture-only actions.
+7. Export only the needed result: changed keys, stable JSON, Markdown ordering, or a prompt that preserves context. Provide clipboard fallback and a visible preview.
+8. Validate with:
+   `node "${CLAUDE_PLUGIN_ROOT}/scripts/validate-html-artifact.mjs" --kind editor <file.html>`
+   Exercise valid, invalid, empty, reset, export, and clipboard-failure paths.
+
+## Non-negotiables
+
+- The source of truth is explicit. Avoid two writers racing over the same state.
+- Every control has a label; every state change has feedback.
+- Never put secrets into a shareable artifact or browser storage.
+- Do not persist by default. If persistence is requested, disclose storage and add clear reset.
+- Export is a primary action, not an afterthought. The exported result must be deterministic and pasteable without cleanup.
+- If the workflow needs live AI round-trips rather than a static export loop, pair with `aio-html-interactive` from `aio-message-bridge`.
+
+## Optional: agent-assisted editing
+
+Use the separately installed companion when the editor should **ask the agent to explain a warning, comment on a field or selection, suggest a valid change, validate a draft, or chat with the current editor state as context**. Keep browser-authoritative fields local unless the event contract explicitly makes the agent authoritative; never let both sides write the same key.
+
+This skill defines the schema, invariants, preview, and export. `aio-html-interactive` owns the frozen UI runtime, relay, Monitor lifecycle, busy state, and push handling. Do not copy its implementation. Read `${CLAUDE_PLUGIN_ROOT}/references/live-collaboration.md` for install instructions, typed event suggestions, security, and lifecycle boundaries.

--- a/plugins/aio-html-artifacts/skills/aio-html-editor/agents/openai.yaml
+++ b/plugins/aio-html-artifacts/skills/aio-html-editor/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Purpose-built HTML Editor"
+  short_description: "Manipulate structured work and export the result"

--- a/plugins/aio-html-artifacts/skills/aio-html-editor/references/editor-contract.md
+++ b/plugins/aio-html-artifacts/skills/aio-html-editor/references/editor-contract.md
@@ -1,0 +1,33 @@
+# Editor contract
+
+Write this contract before HTML:
+
+```text
+Source:        where the initial data came from and its revision
+Schema:        fields, types, IDs, ordering rules
+Operations:    what the user may change
+Invariants:    what must remain true
+Derived state: what previews/scores/warnings are computed
+Dirty state:   how original and current values are compared
+Export:        exact format, ordering, and inclusion rules
+Failure paths: invalid input, empty data, clipboard blocked, reset
+```
+
+## Interaction rules
+
+- Prefer direct manipulation only when it reduces effort; always provide a button/keyboard alternative.
+- Use `aria-live="polite"` for export and validation feedback.
+- Disable impossible actions, but explain why near the control.
+- Confirmation is required for destructive reset when meaningful work may be lost.
+- Keep stable IDs independent of visual order.
+- Serialize deterministically: stable key order, explicit indentation, newline at end when exporting a file.
+- Never claim a change is saved merely because it exists in browser memory.
+
+## Export patterns
+
+- **Copy diff:** only changed keys plus old/new values.
+- **Copy JSON:** complete machine-readable current state.
+- **Copy prompt:** human-readable context, requested changes, constraints, and unresolved warnings.
+- **Download:** use a Blob and revoke the object URL after use.
+
+Clipboard calls can fail on local files or insecure origins. Include a textarea/dialog fallback that selects the full export.

--- a/plugins/aio-html-artifacts/skills/aio-html-explorer/SKILL.md
+++ b/plugins/aio-html-artifacts/skills/aio-html-explorer/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: aio-html-explorer
+description: |
+  Create a self-contained HTML exploration or decision surface that places genuinely different options side by side, aligns tradeoffs on shared criteria, exposes assumptions and falsifiers, and ends with a recommendation or decision record. Use for architecture alternatives, product/design directions, implementation approaches, vendor selection, scenario planning, or requests to compare, brainstorm visually, explore options, or decide in HTML.
+---
+
+# Side-by-side HTML explorer
+
+Use space to reduce memory load: alternatives belong on a shared visual baseline, not in sequential prose.
+
+## Required reading
+
+Read:
+
+- `${CLAUDE_PLUGIN_ROOT}/references/artifact-grammar.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/aio-html-explorer/references/explorer-grammar.md`
+- `${CLAUDE_PLUGIN_ROOT}/references/quality-rubric.md`
+
+Inspect `${CLAUDE_PLUGIN_ROOT}/examples/queue-architecture-explorer.html` for a worked example.
+
+## Workflow
+
+1. State the decision question, decision owner, constraints, and deadline/horizon.
+2. Normalize options. Each must answer the same criteria with comparable evidence and units.
+3. Make options materially different. Do not manufacture three cosmetic variants of one idea.
+4. Build a first-screen option map, then aligned details, then a tradeoff matrix or scenario test.
+5. Show assumptions, confidence, reversibility, failure modes, and what evidence would change the ranking.
+6. If scoring is interactive, expose weights, preserve raw evidence, and show that the score is a model—not truth.
+7. End with a recommendation, accepted tradeoff, and next experiment or decision record.
+8. Validate with:
+   `node "${CLAUDE_PLUGIN_ROOT}/scripts/validate-html-artifact.mjs" --kind explorer <file.html>`
+
+## Non-negotiables
+
+- Use aligned rows/columns or a matrix so comparisons do not depend on memory.
+- Separate hard constraints from preferences.
+- Never hide a disqualifier inside an accordion.
+- Recommendations name both why the winner wins and where it loses.
+- Unknown is an honest value. Do not convert missing evidence into a neutral score.
+- On mobile, transform comparison columns into repeated criterion groups or a scroll-snap comparison with labels retained.
+
+## Optional: deliberate with the agent in place
+
+When the user wants to **select an option claim and ask why, comment on evidence, propose a new constraint, chat about a scenario, or have the agent update the comparison live**, pair this skill with the separately installed `aio-html-interactive` skill from `aio-message-bridge`.
+
+The explorer continues to own comparable criteria, evidence, and recommendation logic. Hand stable option/criterion anchors and typed comment/chat/decision events to the companion skill; let it own the relay and event loop. Do not duplicate its scaffold. Read `${CLAUDE_PLUGIN_ROOT}/references/live-collaboration.md` for the installation and integration boundary.

--- a/plugins/aio-html-artifacts/skills/aio-html-explorer/agents/openai.yaml
+++ b/plugins/aio-html-artifacts/skills/aio-html-explorer/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "HTML Decision Explorer"
+  short_description: "Compare options on a shared visual baseline"

--- a/plugins/aio-html-artifacts/skills/aio-html-explorer/references/explorer-grammar.md
+++ b/plugins/aio-html-artifacts/skills/aio-html-explorer/references/explorer-grammar.md
@@ -1,0 +1,28 @@
+# Explorer grammar
+
+## Decision frame
+
+Put this before the options:
+
+- Question: one decision, not a theme.
+- Constraints: pass/fail conditions.
+- Criteria: qualities that trade off.
+- Horizon: when consequences matter.
+- Evidence state: known, inferred, assumed, unknown.
+
+## Useful compositions
+
+- **Option lanes:** aligned columns for 2–4 alternatives.
+- **Criterion bands:** one row per criterion, options inside the row; best for mobile reflow.
+- **Tradeoff frontier:** two competing dimensions plotted honestly; useful when there is no universal winner.
+- **Scenario switcher:** same options under different demand/cost/risk scenarios.
+- **Reversibility map:** one-way doors versus reversible experiments.
+- **Evidence ledger:** claim, source, confidence, and falsifier.
+
+Avoid score theater. Weighted scoring is useful only when criteria and weights are visible, missing data stays missing, and a sensitivity check shows whether small weight changes flip the answer.
+
+## Recommendation language
+
+Use this structure:
+
+> Choose **X** for **context/horizon** because **decisive evidence**. Accept **specific downside**. Do **experiment or mitigation** before **commit point**. Reconsider if **falsifier** occurs.

--- a/plugins/aio-html-artifacts/skills/aio-html-report/SKILL.md
+++ b/plugins/aio-html-artifacts/skills/aio-html-report/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: aio-html-report
+description: |
+  Create a self-contained, evidence-rich HTML report or explainer with a clear verdict, narrative spine, layered detail, diagrams, exact code/diff/log excerpts, responsive layout, and print mode. Use for code reviews, PR writeups, incident reports, implementation plans, technical explainers, research synthesis, weekly status, audits, and any long-form deliverable where Markdown would hide hierarchy or separate claims from proof.
+---
+
+# Evidence-led HTML report
+
+Produce one readable `.html` file whose first screen tells the truth and whose deeper layers let a skeptical reader audit it.
+
+## Required reading
+
+Read these before composing:
+
+- `${CLAUDE_PLUGIN_ROOT}/references/artifact-grammar.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/aio-html-report/references/report-structures.md`
+- `${CLAUDE_PLUGIN_ROOT}/references/quality-rubric.md`
+
+Use `${CLAUDE_PLUGIN_ROOT}/examples/engineering-investigation-report.html` as a capability example, not as a template to recolor.
+
+## Workflow
+
+1. **Ground the evidence.** Inspect the requested sources. Capture exact identifiers, time, revisions, file/symbol/line anchors, quotes, and gaps. Separate observed facts from inference.
+2. **Write the report contract.** One sentence each for audience, question, decision/action, and what a careful reader could challenge.
+3. **Choose one report structure** from `report-structures.md`. Write the narrative spine before HTML.
+4. **Sketch the five layers.** Decide what belongs in glance, scan, understand, audit, and act. Do not repeat the same paragraph at each depth.
+5. **Map relationships to visuals.** Use a timeline for sequence, flow for causality, aligned columns for comparison, and annotated code for code claims. Never default to a grid of cards.
+6. **Compose a self-contained file.** Inline CSS, SVG, and minimal JS. Prefer semantic HTML and a readable no-JS order.
+7. **Verify.** Run:
+   `node "${CLAUDE_PLUGIN_ROOT}/scripts/validate-html-artifact.mjs" --kind report <file.html>`
+   Then inspect desktop, mobile, and print as required by the shared grammar.
+8. **Hand off the file.** State the verdict and link the output. Mention evidence gaps and any validator warnings.
+
+## Non-negotiables
+
+- Lead with the conclusion, confidence, and consequence—not a decorative title.
+- If discussing source code and it is available, show the decisive lines inline with annotations.
+- Provide navigation only when it reduces navigation cost; short reports do not need a sidebar.
+- Use `<details>` for audit depth, never to conceal the core conclusion.
+- Charts require units, scale/baseline, source, and a textual takeaway.
+- Avoid KPI tiles unless the numbers truly answer the opening question.
+- Do not use interactivity as decoration. Reports are readable before JavaScript runs.
+
+## Optional: make the report a live reading room
+
+When the user wants to read a report or plan and **select unclear text/code, leave an anchored comment, request an explanation, or chat inside the HTML with section context**, pair this skill with the separately installed `aio-html-interactive` skill from `aio-message-bridge`.
+
+Keep this skill responsible for the report spine and evidence. Hand the live layer stable section/source anchors plus a small event contract such as `explain.request`, `comment.submit`, and `chat.submit`; let the companion skill own its scaffold, relay, Monitor loop, busy state, and cleanup. Do not copy that implementation into the report. Read `${CLAUDE_PLUGIN_ROOT}/references/live-collaboration.md` only when this live tier is requested; it includes the install command and handoff contract.

--- a/plugins/aio-html-artifacts/skills/aio-html-report/agents/openai.yaml
+++ b/plugins/aio-html-artifacts/skills/aio-html-report/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "HTML Evidence Report"
+  short_description: "Turn evidence into a layered, auditable HTML report"

--- a/plugins/aio-html-artifacts/skills/aio-html-report/references/report-structures.md
+++ b/plugins/aio-html-artifacts/skills/aio-html-report/references/report-structures.md
@@ -1,0 +1,31 @@
+# Report structures
+
+Choose the structure that matches the reader's question. Do not combine all of them.
+
+## Investigation / code review
+
+Verdict → scope and method → system path → findings ordered by severity → code/diff evidence beside each finding → cross-system implications → recommendation → verification checklist → evidence register.
+
+## Incident
+
+Current state → impact → event timeline → causal chain → contributing conditions → response evaluation → corrective actions with owner/date → detection gaps → appendix. Keep chronology and causality distinct.
+
+## Implementation plan
+
+Outcome and constraints → current state → proposed flow → milestones and dependencies → key interfaces/code → rollout and observability → risks/mitigations → unresolved decisions → definition of done.
+
+## Research / explainer
+
+Answer in one sentence → mental model → guided walkthrough → worked example → common failure modes → evidence/citations → implications → questions still open.
+
+## Status
+
+Trajectory → what materially changed → shipped outcomes → risk/carryover → decisions or help needed → next horizon. Avoid activity inventories with no consequence.
+
+## Composition patterns
+
+- Use a narrow reading column for reasoning and a wider breakout for diagrams, tables, and code.
+- Use a rail for metadata, legend, or navigation only when it stays useful across several sections.
+- Use margin callouts to connect findings to exact lines.
+- Use a visual seam—rule, large whitespace, or contrast shift—when the story changes phase.
+- End with action at the same specificity as the evidence: owner, condition, due date, command, or decision.


### PR DESCRIPTION
## What changed

- add the `aio-html-artifacts` marketplace plugin at v1.0.0
- add four focused skills: evidence-led reports, narrative decks, decision explorers, and purpose-built editors
- add a shared five-layer information grammar, research foundations, quality rubric, and optional live-collaboration contract for pairing with `aio-html-interactive` / `aio-message-bridge`
- add four original, self-contained HTML examples plus a deterministic artifact validator
- register the plugin in the marketplace and root README

## Why

Markdown serializes relationships that are easier to understand spatially or interactively. This plugin gives agents a repeatable way to choose the right HTML form for the human job, keep claims close to evidence, support multiple reading depths, and close the loop through actions or exports.

The live-agent tier remains optional: users can install `aio-message-bridge` separately for selection-based explanations, anchored comments, contextual chat, and live decisions without vendoring or duplicating that runtime.

## Impact

- marketplace users can install `aio-html-artifacts` as a four-skill bundle
- generated artifacts are standalone, responsive, accessible, printable, and dependency-free by default
- the marketplace website will regenerate and deploy automatically after merge to `main`

## Validation

- `bash scripts/validate-marketplace.sh` — 29/29 plugins, 416/416 checks
- all four skills pass `quick_validate.py`
- plugin passes `validate_plugin.py`
- all four HTML examples pass `validate-html-artifact.mjs` with zero warnings
- rendered at 1440×900 and 390×844 with no page overflow or JavaScript errors
- exercised deck navigation, explorer scenarios, editor constraint/diff/reset flows
- print-tested: report 4 A4 pages; deck 6 16:9 pages
- local verified-secret scan found no leaks
